### PR TITLE
Removing global NPM dependencies (grunt, mocha)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,18 @@ Currently only some parts of the runtime are developed:
 - array data-bindings (i.e. automatic refresh of foreach nodes when the foreach array is changed)
 
 
-To run and update the samples in a live environment, you will have to install [grunt][grunt] and then:
-- run *grunt* to launch a local web-server that can compile templates on the fly (cf. hsp/grunt folder)
+To run and update the samples in a live environment, first run *npm install* and then:
+- run *npm run-script grunt* to launch a local web-server that can compile templates on the fly (cf. hsp/grunt folder)
 - open *http://localhost:8000* in your favorite browser and choose an example from the sample list
 - or open *http://localhost:8000/todomvc* to play with the todomvc sample..
 
 Running Tests
 -------------
-To run the project you will have to install [grunt][grunt] and [mocha][mocha]
-
 For the compiler test:
-- run *mocha test*
+- run *npm run-script mocha*
 
 For the browser runtime tests:
-- run *grunt* - this will launch a local webserver and a watch task on your files
+- run *npm run-script grunt* - this will launch a local webserver and a watch task on your files
 - and access *http://localhost:8000/test/rt* to run the tests in your favorite browsers
 
 

--- a/hsp/grunt/grunt-cli.js
+++ b/hsp/grunt/grunt-cli.js
@@ -1,0 +1,6 @@
+/*
+ * This script is used both in ../package.json and grunt-tasks/task-forkgrunt.js.
+ * It locally does the job of what a global installation of the grunt-cli npm module would do.
+ */
+var grunt = require('grunt');
+grunt.cli();

--- a/package.json
+++ b/package.json
@@ -19,10 +19,13 @@
         "jasmine-node": "1.0.26",
         "socket.io" : "0.9.13",
         "express" : "3.0.6",
-        "request" : "2.12.0"
+        "request" : "2.12.0",
+        "mocha-runner" : "0.0.3"
     },
     "scripts": {
-        "test": "node node_modules/grunt/bin/grunt test"
+        "test" : "node node_modules/grunt/bin/grunt test",
+        "grunt" : "node hsp/grunt/grunt-cli.js",
+        "mocha" : "node test/runner/mocha-cli.js"
     },
     "config": {
         "test-browsers": "Firefox"

--- a/test/runner/mocha-cli.js
+++ b/test/runner/mocha-cli.js
@@ -1,0 +1,8 @@
+var Runner = require ("mocha-runner");
+
+new Runner ({
+	tests: ["../alltests"]
+}).run (function (error){
+    //It's not the Mocha stderr
+    if (error) console.log (error);
+});


### PR DESCRIPTION
Let's use local dependency instead of global ones.

Scripts can be started with:
npm run-script grunt
npm run-script mocha
