### PR TITLE
Build simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,21 @@ To run and update the samples in a live environment, first run *npm install* and
 - open *http://localhost:8000* in your favorite browser and choose an example from the sample list
 - or open *http://localhost:8000/todomvc* to play with the todomvc sample..
 
-Running Tests
--------------
+## Development
+
+### Preparing your environment
+
+- install Grunt cli globally: `npm install -g grunt-cli`
+- install local npm modules: `npm install`
+
+### Running Tests
+
 For the compiler test:
-- run *npm run-script mocha*
+- run `grunt mochaTest`
 
 For the browser runtime tests:
-- run *npm run-script grunt* - this will launch a local webserver and a watch task on your files
+- run *grunt* - this will launch a local webserver and a watch task on your files
 - and access *http://localhost:8000/test/rt* to run the tests in your favorite browsers
-
 
 [key_features_blog]: http://ariatemplates.com/blog/2012/11/key-features-for-client-side-templates/
 [todomvc]: http://addyosmani.github.com/todomvc/

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -15,6 +15,17 @@
 
 module.exports = function (grunt) {
   grunt.initConfig({
+    mochaTest: {
+      test: {
+        options: {
+          reporter: 'spec'
+        },
+        src: [
+          'public/test/compiler/*.js',
+          'public/test/jsvalidator/*.js'
+        ]
+      }
+    },
     hspserver: {
       port: 8000,
       base: __dirname,
@@ -27,6 +38,7 @@ module.exports = function (grunt) {
   });
 
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadTasks('hsp/grunt');
 
   grunt.registerTask('default', ['hspserver','watch']);

--- a/hsp/grunt/grunt-cli.js
+++ b/hsp/grunt/grunt-cli.js
@@ -1,6 +1,0 @@
-/*
- * This script is used both in ../package.json and grunt-tasks/task-forkgrunt.js.
- * It locally does the job of what a global installation of the grunt-cli npm module would do.
- */
-var grunt = require('grunt');
-grunt.cli();

--- a/package.json
+++ b/package.json
@@ -1,33 +1,26 @@
 {
-    "author": "ariatemplates <contact@ariatemplates.com> (http://github.com/ariatemplates)",
-    "name": "hashspace-prototype",
-    "description": "hashspace runtime prototype",
-    "version": "0.0.1-SNAPSHOT",
-    "homepage": "",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/ariatemplates/hashspace.git"
-    },
-    "dependencies": {
-        "acorn":"0.1.0",
-        "pegjs" : "0.7.0"
-    },
-    "devDependencies": {
-        "grunt": "0.4.0",
-        "grunt-jasmine-node": "0.0.2",
-        "grunt-contrib-watch": "0.5.3",
-        "jasmine-node": "1.0.26",
-        "socket.io" : "0.9.13",
-        "express" : "3.0.6",
-        "request" : "2.12.0",
-        "mocha-runner" : "0.0.3"
-    },
-    "scripts": {
-        "test" : "node node_modules/grunt/bin/grunt test",
-        "grunt" : "node hsp/grunt/grunt-cli.js",
-        "mocha" : "node public/test/runner/mocha-cli.js"
-    },
-    "config": {
-        "test-browsers": "Firefox"
-    }
+  "author": "ariatemplates <contact@ariatemplates.com> (http://github.com/ariatemplates)",
+  "name": "hashspace-prototype",
+  "description": "hashspace runtime prototype",
+  "version": "0.0.1-SNAPSHOT",
+  "homepage": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ariatemplates/hashspace.git"
+  },
+  "dependencies": {
+    "acorn": "0.1.0",
+    "pegjs": "0.7.0"
+  },
+  "devDependencies": {
+    "grunt": "0.4.0",
+    "grunt-contrib-watch": "0.5.3",
+    "socket.io": "0.9.13",
+    "express": "3.0.6",
+    "request": "2.12.0",
+    "grunt-mocha-test": "~0.7.0"
+  },
+  "config": {
+    "test-browsers": "Firefox"
+  }
 }

--- a/public/test/alltests.js
+++ b/public/test/alltests.js
@@ -1,5 +1,0 @@
-
-// All moch tests
-require('./compiler/tests');
-require('./compiler/errtests');
-require('./jsvalidator/tests');

--- a/public/test/runner/mocha-cli.js
+++ b/public/test/runner/mocha-cli.js
@@ -1,8 +1,0 @@
-var Runner = require ("mocha-runner");
-
-new Runner ({
-	tests: ["../alltests"]
-}).run (function (error){
-    //It's not the Mocha stderr
-    if (error) console.log (error);
-});


### PR DESCRIPTION
@b-laporte @mlaval I had 1h of downtime so took a stab at testing thing. My vision of the things is:
- run compiler tests (node-based) on each build of the framework
- runt runtime tests (browser-based) through a runner (my dream: karma + soucelabs)

Those 2 commits are going in this direction by moving all the tasks to grunt, which now is the one and only entry point to the whole build. Also, those commits are removing hand-written tasks for code that exists in npm (mostly grunt tasks).
