### PR TITLE
add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+ language: node_js
+ node_js:
+   - "0.10"
+
+ before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - npm install --quiet -g grunt-cli
+  - npm install
+
+ script: grunt

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://secure.travis-ci.org/ariatemplates/hashspace.png)](http://travis-ci.org/ariatemplates/hashspace)
+
 hashspace
 =========
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -44,5 +44,6 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadTasks('hsp/grunt');
 
-  grunt.registerTask('default', ['hspserver','watch']);
+  grunt.registerTask('default', ['checkStyle', 'mochaTest']);
+  grunt.registerTask('server', ['hspserver','watch']);
 };


### PR DESCRIPTION
This also changes the default task to run jshint checks and tests. Server can be started by running `grunt server`
