### PR TITLE
Support browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_STORE
 ._.DS_STORE
+build

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -34,6 +34,73 @@ module.exports = function (grunt) {
     watch: {
       files: ['*.*'],
       tasks: []
+    },
+    copy: {
+      fs_module: {
+        files: [{
+          src: 'hsp/compiler/hspblocks.pegjs',
+          dest: 'build/tmp/fs.js'
+        }],
+        options: {
+          processContent: function (content, srcpath) {
+            return "exports.readFileSync=function(){return " + JSON.stringify(content) + "}";
+          }
+        }
+      }
+    },
+    browserify: {
+      runtime: {
+        files: {
+          'build/hashspace.js': ['hsp/rt.js']
+        },
+        options: {
+          aliasMappings: [
+            {
+              cwd: "hsp",
+              src: ['*.js'],
+              dest: 'hsp'
+            },
+            {
+              cwd: "hsp/rt",
+              src: ['*.js'],
+              dest: 'hsp/rt'
+            },
+            {
+              cwd: "hsp/gestures",
+              src: ['*.js'],
+              dest: 'hsp/gestures'
+            }
+          ]
+        }
+      },
+      compiler: {
+        files: {
+          'build/hashspace.compiler.js': ['hsp/compiler/compiler.js']
+        },
+        options: {
+          aliasMappings: [
+            {
+              cwd: "hsp/compiler",
+              src: ['compiler.js'],
+              dest: 'hsp'
+            }
+          ],
+          shim: {
+            fs: {
+              path: 'build/tmp/fs.js',
+              exports: null
+            }
+          }
+        }
+      }
+    },
+    uglify: {
+      hsp: {
+        files: {
+          'build/hashspace.min.js': ['build/hashspace.js'],
+          'build/hashspace.compiler.min.js': ['build/hashspace.compiler.js']
+        }
+      }
     }
   });
 
@@ -42,8 +109,12 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-verifylowercase');
   grunt.loadNpmTasks('grunt-leading-indent');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadTasks('hsp/grunt');
 
   grunt.registerTask('test', ['checkStyle','mochaTest']);
+  grunt.registerTask('package', ['copy', 'browserify', 'uglify']);
   grunt.registerTask('default', ['hspserver','watch']);
 };

--- a/hsp/compiler/compiler.js
+++ b/hsp/compiler/compiler.js
@@ -105,7 +105,7 @@ exports.compile = function (template, fileName, includeSyntaxTree, bypassJSvalid
         }
     }
 
-    res.code += getErrorScript(res.errors);
+    res.code += getErrorScript(res.errors, fileName);
 
     if (includeSyntaxTree !== true) {
         res.syntaxTree = null;
@@ -118,10 +118,10 @@ exports.compile = function (template, fileName, includeSyntaxTree, bypassJSvalid
  * Generate an error script to include in the template compiled script in order to show errors in the browser when the
  * script is loaded
  */
-function getErrorScript (errors) {
+function getErrorScript (errors, fileName) {
     var r = '';
     if (errors && errors.length) {
-        r = ['\r\nrequire("hsp/rt").logErrors(__filename,', JSON.stringify(errors, null), ');\r\n'].join("");
+        r = ['\r\nrequire("hsp/rt").logErrors("', fileName, '",', JSON.stringify(errors, null), ');\r\n'].join("");
     }
     return r;
 }

--- a/package.json
+++ b/package.json
@@ -13,16 +13,20 @@
     "pegjs": "0.7.0"
   },
   "devDependencies": {
-    "grunt-verifylowercase": "0.2.0",
-    "grunt-leading-indent": "0.1.0",
-    "grunt": "0.4.0",
-    "grunt-contrib-jshint": "0.6.3",
-    "grunt-contrib-watch": "0.5.3",
+    "grunt-verifylowercase": "~0.2.0",
+    "grunt-leading-indent": "~0.1.0",
+    "grunt": "~0.4.2",
+    "grunt-contrib-jshint": "0.7.2",
+    "grunt-contrib-watch": "~0.5.3",
     "express": "3.0.6",
     "request": "2.12.0",
-    "grunt-mocha-test": "~0.7.0"
+    "grunt-mocha-test": "~0.7.0",
+    "grunt-browserify": "~1.3.0",
+    "grunt-contrib-uglify": "~0.2.7",
+    "grunt-contrib-copy": "~0.4.1"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "prepublish": "grunt package"
   }
 }

--- a/public/test/compiler/errtests.js
+++ b/public/test/compiler/errtests.js
@@ -38,7 +38,7 @@ describe('Template compilation errors: ', function () {
         var s = [
                 compiler.HEADER,
                 '\r\n',
-                'require("hsp/rt").logErrors(__filename,[{',
+                'require("hsp/rt").logErrors("mixed1",[{',
                 '"description":"SyntaxError: Unexpected token",',
                 '"lineInfoTxt":"    foo({blah:\\\"hello\\\",});\\r\\n----------------------^--",',
                 '"lineInfoHTML":"<span class=\\\"code\\\">    foo({blah:\\\"hello\\\",<span class=\\\"error\\\" title=\\\"SyntaxError: Unexpected token\\\">}</span>);</span>",',


### PR DESCRIPTION
Add a `prepublish` script to generate a standalone version of hashspace that can be easily dropped in the browser.
This avoid the need of other script loaders.
Keeps the compiler separate for the runtime.

**Usage (node)**
`npm install`
or
`grunt package`

**Output**
Creates 4 different files in `build/` folder
`hashspace.js` (and .min)
`hashspace.compiler.js` (and .min)

**Why**
There's no need to use a script loader to use hashspace, and having a single file to put in the page is a much simpler setup.
For production `hashspace.js` is all you need (btw it's now ~30kB), it corresponds to 'hsp/rt'.

For easy development you can include also `hashspace.compiler.js` and compile your templates in the browser.

Once more, in production there's no need of the compiler, ideally all templates should be compiled offline and served in any way you like.

**Usage (browser)**

``` html
<!DOCTYPE html>
<html>
    <head>
        <title>Hashspace</title>
        <script type="text/template" id="helloworld">
            # template hello(name)
                <div class="msg">
                    Hello {name}!
                </div>
            # /template
        </script>
    </head>
    <body>
        <div id="output"></div>

        <script src="/jquery.min.js"></script>
        <script src="/hashspace.min.js"></script>
        <script src="/hashspace.compiler.min.js"></script>

        <script type="text/javascript">
        // This is only needed in development phase to compile templates
        // In production the templates should be already pre-compiled
        var compiler = require("hsp/compiler");
        var template = compiler.compile($.trim($("#helloworld").html()));
        eval(template.code);


        // Once in production that's all you need
        hello("Fabio").render("output");
        </script>
    </body>
</html>
```

**Comments**

I've included the built file in the repository, I think it makes more sense, people can simply grab the file from here.
But if you prefer I can exclude the build folder from git

jQuery is only needed to get the template content, you can live without, but nowadays every project includes already jQuery.

Hope you like it :wink: 
