### PR TITLE
karma runner and saucelabs integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_STORE
 ._.DS_STORE
 build
+sauce_connect.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ node_js:
 
 before_install:
  - npm install --quiet -g grunt-cli
+
+before_script:
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ For jshint validation:
 For the compiler test:
 - run `grunt mochaTest`
 
+For the browser-based runtime tests:
+- run `grunt karma:unit` (you can also work in the TDD mode by running `grunt karma:tdd`)
+
+To do the health check on the project (before commit, for example) run `grunt test`. This will run
+
 For the browser runtime tests:
 - run *grunt* - this will launch a local webserver and a watch task on your files
 - and access *http://localhost:8000/test/rt* to run the tests in your favorite browsers

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -26,6 +26,90 @@ module.exports = function (grunt) {
         ]
       }
     },
+    karma: {
+      options: {
+        frameworks: ['jasmine', 'commonjs'],
+        files: [
+          'hsp/**/*.js',
+          'public/test/lib/fireDomEvent.js',
+          'public/test/lib/type.js',
+          'public/test/**/*.spec.js'
+        ],
+        exclude: [
+          'hsp/grunt/**/*.js',
+          'hsp/compiler/**/*.js',
+          'public/test/compiler/**/*.spec.js'
+        ],
+        preprocessors: {
+          'hsp/**/*.js': ['commonjs'],
+          'public/test/lib/*.js': ['commonjs'],
+          'public/test/**/*.spec.js': ['commonjs']
+        },
+        commonjsPreprocessor: {
+          modulesRoot: '.'
+        },
+        // global config for SauceLabs
+        sauceLabs: {
+          username: 'ariatemplates',
+          accessKey: '620e638e-90d2-48e1-b66c-f9505dcb888b',
+          testName: '#space runtime tests'
+        },
+        // define SL browsers
+        customLaunchers: {
+          'SL_IE_8': {
+            base: 'SauceLabs',
+            browserName: 'internet explorer',
+            platform: 'Windows 7',
+            version: '8'
+          },
+          'SL_IE_9': {
+            base: 'SauceLabs',
+            browserName: 'internet explorer',
+            platform: 'Windows 2008',
+            version: '9'
+          },
+          'SL_IE_10': {
+            base: 'SauceLabs',
+            browserName: 'internet explorer',
+            platform: 'Windows 2012',
+            version: '10'
+          },
+          'SL_IE_11': {
+            base: 'SauceLabs',
+            browserName: 'internet explorer',
+            platform: 'Windows 8.1',
+            version: '11'
+          },
+          'ANDROID': {
+            base: 'SauceLabs',
+            browserName: 'android',
+            platform: 'Linux',
+            version: '4.0'
+          },
+          'IOS': {
+            base: 'SauceLabs',
+            browserName: 'iphone',
+            platform: 'OS X 10.8',
+            version: '6.0'
+          }
+        }
+        //logLevel: 'LOG_INFO'
+      },
+      unit: {
+        browsers: ['Firefox'],
+        singleRun: true
+      },
+      tdd: {
+        browsers: ['Firefox'],
+        singleRun: false,
+        autoWatch: true
+      },
+      ci: {
+        singleRun: true,
+        browsers: ['Firefox', 'SL_IE_8', 'SL_IE_9', 'SL_IE_10'],
+        reporters: ['progress', 'saucelabs']
+      }
+    },
     hspserver: {
       port: 8000,
       base: __dirname,
@@ -112,9 +196,11 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-karma');
   grunt.loadTasks('hsp/grunt');
 
-  grunt.registerTask('test', ['checkStyle','mochaTest']);
   grunt.registerTask('package', ['copy', 'browserify', 'uglify']);
+  grunt.registerTask('test', ['checkStyle','mochaTest', 'karma:unit']);
+  grunt.registerTask('ci', ['checkStyle','mochaTest', 'karma:ci']);
   grunt.registerTask('default', ['hspserver','watch']);
 };

--- a/hsp/rt/exphandler.js
+++ b/hsp/rt/exphandler.js
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2012 Amadeus s.a.s.
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "grunt-mocha-test": "~0.7.0",
     "grunt-browserify": "~1.3.0",
     "grunt-contrib-uglify": "~0.2.7",
-    "grunt-contrib-copy": "~0.4.1"
+    "grunt-contrib-copy": "~0.4.1",
+    "grunt-karma": "~0.6.2",
+    "karma-commonjs": "0.0.5",
+    "karma-sauce-launcher": "~0.1.7"
   },
   "scripts": {
     "test": "grunt test",

--- a/public/test/rt/json.spec.js
+++ b/public/test/rt/json.spec.js
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2012 Amadeus s.a.s.
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/public/test/rt/text.spec.js
+++ b/public/test/rt/text.spec.js
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2012 Amadeus s.a.s.
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -307,6 +306,5 @@ describe("Text Nodes", function () {
     });
 
 });
-
 
 // TODO test root node with multiple chile nodes


### PR DESCRIPTION
So, this is long talked-about PR introducing Karma runner with https://saucelabs.com/home integration which is going to allow us to run tests on multiple platforms and different browsers.

Integration with Karma runner (http://karma-runner.github.io/0.10/index.html) allows us to run `grunt karma:unit` to run Jasmine tests in a browser(s) of choice (we can also run `grunt test` to run both server-side and client-side tests). 

For now saucelabs is not integrated with Travis but you can run `grunt ci` to see how it feels. Currently tests are run on multiple versions of IE and 3 tests are failing on IE8 (surprise, surprise). Watch out - it takes some time to run those tests on sauce... 
