### PR TITLE
Transpiler (to replace a.b = c by $set(a,"b",c) in js code)

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -22,6 +22,7 @@ module.exports = function (grunt) {
         },
         src: [
           'public/test/compiler/*.js',
+          'public/test/transpiler/*.js',
           'public/test/compiler/jsvalidator/*.js'
         ]
       }
@@ -40,6 +41,7 @@ module.exports = function (grunt) {
         ],
         exclude: [
           'hsp/compiler/**/*.js',
+          'public/test/transpiler/**/*.spec.js',
           'public/test/compiler/**/*.spec.js'
         ],
         preprocessors: {

--- a/hsp/$set.js
+++ b/hsp/$set.js
@@ -1,8 +1,50 @@
-var json=require("hsp/json");
+var json = require("./json");
 
 /**
- * Shortcut to json.set()
+ * Shortcut to json.$set()
  */
-module.exports = function(object, property, value) {
-    json.set(object, property, value);
+var $set = module.exports = function (object, property, value) {
+    return json.$set(object, property, value);
+};
+
+/**
+ * Shortcut to json.$delete()
+ */
+$set.del = json.$delete;
+
+var cachedOperators = {};
+
+function createOperator (operator) {
+    /*jshint -W061,-W093 */
+    return cachedOperators[operator] = Function("a", "b", "a" + operator + "b;return a;");
+    /*jshint +W061,+W093*/
+}
+
+/**
+ * Does an assignment operation but also notifies listeners.
+ * <code>$set.op(a,b,"+=",c)</code> is equivalent to <code>a[b] += c</code>
+ */
+$set.op = function (object, property, operator, value) {
+    var opFn = cachedOperators[operator] || createOperator(operator);
+    return $set(object, property, opFn(object[property], value));
+};
+
+/**
+ * Increments a property on an object and notifies listeners.
+ * <code>$set.inc(a,b)</code> is equivalent to <code>a[b]++</code>
+ */
+$set.inc = function (object, property) {
+    var previousValue = object[property];
+    $set(object, property, previousValue + 1);
+    return previousValue;
+};
+
+/**
+ * Decrements a property on an object and notifies listeners.
+ * <code>$set.dec(a,b)</code> is equivalent to <code>a[b]--</code>
+ */
+$set.dec = function (object, property) {
+    var previousValue = object[property];
+    $set(object, property, previousValue - 1);
+    return previousValue;
 };

--- a/hsp/transpiler/formatAST.js
+++ b/hsp/transpiler/formatAST.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function (ast, fileContent, options) {
+    options = options || {};
+    var UglifyJS = options["uglify-js"] || require("uglify-js");
+
+    fileContent = fileContent.replace(/\r\n?|[\n\u2028\u2029]/g, "\n").replace(/\uFEFF/g, "");
+
+    var nextStart = null;
+    var out = [];
+
+    function continueUntil (newPosition) {
+        if (nextStart !== null && newPosition > nextStart) {
+            out.push(fileContent.substring(nextStart, newPosition));
+        }
+        nextStart = null;
+    }
+
+    function restartFrom (newPosition) {
+        nextStart = newPosition;
+    }
+
+    function walkFunction (node, descend) {
+        var formatInfo = node.formatInfo;
+        if (formatInfo) {
+            continueUntil(formatInfo.originalStartPos);
+            out.push(formatInfo.before);
+            var middle = formatInfo.middle;
+            for (var i = 0, l = middle.length; i < l; i++) {
+                if (i > 0) {
+                    out.push(", ");
+                }
+                walkNode(middle[i]);
+            }
+            out.push(formatInfo.after);
+            restartFrom(formatInfo.originalEndPos);
+        } else if (!(node.start && node.end)) {
+            out.push(node.print_to_string());
+        } else {
+            var newStart = (nextStart === null);
+            if (newStart) {
+                restartFrom(node.start.pos);
+            }
+            descend();
+            if (newStart) {
+                continueUntil(node.end.endpos);
+            }
+        }
+        return true;
+    }
+
+    function walkNode (node) {
+        var walker = new UglifyJS.TreeWalker(walkFunction);
+        node.walk(walker);
+    }
+
+    walkNode(ast);
+    return out.join("");
+};

--- a/hsp/transpiler/index.js
+++ b/hsp/transpiler/index.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+    processString : require("./processString"),
+    processAST : require("./processAST"),
+    formatAST : require("./formatAST")
+};

--- a/hsp/transpiler/processAST.js
+++ b/hsp/transpiler/processAST.js
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var preIncDec = {
+    "++" : "+=",
+    "--" : "-="
+};
+
+var postIncDec = {
+    "++" : "inc",
+    "--" : "dec"
+};
+
+module.exports = function (ast, options) {
+    options = options || {};
+    var UglifyJS = options["uglify-js"] || require("uglify-js");
+
+    function getPropertyName (propAccess) {
+        if (propAccess instanceof UglifyJS.AST_Dot) {
+            return new UglifyJS.AST_String({
+                value : propAccess.property
+            });
+        } else {
+            return propAccess.property;
+        }
+    }
+
+    function createCallRuntimeMethod (method, args, originalNode) {
+        var $setRef = new UglifyJS.AST_SymbolRef({
+            name : "$set"
+        });
+        var res = new UglifyJS.AST_Call({
+            expression : method == "$set" ? $setRef : new UglifyJS.AST_Dot({
+                expression : $setRef,
+                property : method
+            }),
+            args : args
+        });
+        res.formatInfo = {
+            before : (method == "$set" ? method : "$set." + method) + "(",
+            middle : args,
+            after : ")",
+            originalStartPos : originalNode.start.pos,
+            originalEndPos : originalNode.end.endpos
+        };
+        return res;
+    }
+
+    var createRequire = function () {
+        var res = new UglifyJS.AST_Var({
+            definitions : [new UglifyJS.AST_VarDef({
+                name : new UglifyJS.AST_SymbolVar({
+                    name : "$set"
+                }),
+                value : new UglifyJS.AST_Call({
+                    expression : new UglifyJS.AST_SymbolRef({
+                        name : "require"
+                    }),
+                    args : [new UglifyJS.AST_String({
+                        value : "hsp/$set"
+                    })]
+                })
+            })]
+        });
+        res.formatInfo = {
+            before : res.print_to_string(),
+            middle : [],
+            after : "; ",
+            originalStartPos : 0,
+            originalEndPos : 0
+        };
+        return res;
+    };
+
+    function replaceAssignment (node, aDotB) {
+        if (node.operator == "=") {
+            return createCallRuntimeMethod("$set", [aDotB.expression, getPropertyName(aDotB), node.right], node);
+        } else {
+            return createCallRuntimeMethod("op", [aDotB.expression, getPropertyName(aDotB), new UglifyJS.AST_String({
+                        value : node.operator
+                    }), node.right], node);
+        }
+        return node;
+    }
+
+    function replacePostIncDec (node, aDotB) {
+        return createCallRuntimeMethod(postIncDec[node.operator], [aDotB.expression, getPropertyName(aDotB)], node);
+    }
+
+    function replacePreIncDec (node, aDotB, options) {
+        return createCallRuntimeMethod("op", [aDotB.expression, getPropertyName(aDotB), new UglifyJS.AST_String({
+                    value : preIncDec[node.operator]
+                }), new UglifyJS.AST_Number({
+                    value : 1
+                })], node, aDotB);
+    }
+
+    function replaceDelete (node, aDotB, options) {
+        return createCallRuntimeMethod("del", [aDotB.expression, getPropertyName(aDotB)], node);
+    }
+
+    var changed = false;
+    var transformer = new UglifyJS.TreeTransformer(function (node, descend) {
+        descend(node, this);
+        var replacer = null;
+        var aDotB = null;
+        if (node instanceof UglifyJS.AST_Assign) {
+            aDotB = node.left;
+            replacer = replaceAssignment;
+        } else if (node instanceof UglifyJS.AST_Unary) {
+            aDotB = node.expression;
+            if (node.operator == "delete") {
+                replacer = replaceDelete;
+            } else if (preIncDec.hasOwnProperty(node.operator)) {
+                replacer = node instanceof UglifyJS.AST_UnaryPostfix ? replacePostIncDec : replacePreIncDec;
+            }
+        }
+        if (replacer && aDotB instanceof UglifyJS.AST_PropAccess) {
+            changed = true;
+            node = replacer(node, aDotB);
+        }
+        if (changed && node instanceof UglifyJS.AST_Toplevel) {
+            node.body.unshift(createRequire());
+        }
+        return node;
+    });
+    ast.transform(transformer);
+    return changed;
+};

--- a/hsp/transpiler/processString.js
+++ b/hsp/transpiler/processString.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var processAST = require("./processAST");
+var formatAST = require("./formatAST");
+
+module.exports = function (fileContent, fileName, options) {
+    options = options || {};
+    var UglifyJS = options["uglify-js"] || require("uglify-js");
+    var ast = UglifyJS.parse(fileContent, {
+        filename : fileName
+    });
+    var changed = processAST(ast, options);
+    return {
+        changed : changed,
+        code : changed ? formatAST(ast, fileContent, options) : fileContent,
+        ast : ast
+    };
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "acorn": "0.1.0",
-    "pegjs": "0.7.0"
+    "pegjs": "0.7.0",
+    "uglify-js": "2.4.11"
   },
   "devDependencies": {
     "grunt-verifylowercase": "~0.2.0",

--- a/public/test/transpiler/processString.spec.js
+++ b/public/test/transpiler/processString.spec.js
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var vm = require("vm");
+var assert = require("assert");
+var processString = require("../../../hsp/transpiler/processString");
+var $set = require("../../../hsp/$set");
+var json = require("../../../hsp/json");
+
+describe("Transpiler", function () {
+
+    function runJsCode (code) {
+        return vm.runInNewContext(code, {
+            require : function (requiredFile) {
+                assert.equal(requiredFile, "hsp/$set");
+                return $set;
+            }
+        });
+    }
+
+    it("tests processed code", function () {
+        var mySourceFunction = function (a) {
+            a.a = 1;
+            a.a += 1;
+            a.b = ++a.a;
+            a.c = a.a++;
+            a.d = 10;
+            a.e = --a.d;
+            a.f = a.d--;
+            a.d -= 10;
+            a.g = "ok";
+            a.h = a.g == "ok" ? "ok" : "ko";
+            delete a.g;
+            a.i = 2;
+            a.i *= 4;
+            a.i /= 2;
+            a.i %= 3;
+            a.i <<= 4;
+            a.i &= 16;
+            a.i >>= 2;
+            a.i >>>= 2;
+            a.i = -1;
+            a.i ^= 1;
+            a.i |= 1;
+        };
+        var result = processString("(" + mySourceFunction.toString() + ")");
+        assert.equal(result.changed, true);
+        var myProcessedFunction = runJsCode(result.code);
+
+        var a1 = {};
+        var a2 = {};
+        var expectedChgList = [{
+                    type : "new",
+                    name : "a",
+                    newValue : 1,
+                    oldValue : undefined
+                }, {
+                    type : "updated",
+                    name : "a",
+                    newValue : 2,
+                    oldValue : 1
+                }, {
+                    type : "updated",
+                    name : "a",
+                    newValue : 3,
+                    oldValue : 2
+                }, {
+                    type : "new",
+                    name : "b",
+                    newValue : 3,
+                    oldValue : undefined
+                }, {
+                    type : "updated",
+                    name : "a",
+                    newValue : 4,
+                    oldValue : 3
+                }, {
+                    type : "new",
+                    name : "c",
+                    newValue : 3,
+                    oldValue : undefined
+                }, {
+                    type : "new",
+                    name : "d",
+                    newValue : 10,
+                    oldValue : undefined
+                }, {
+                    type : "updated",
+                    name : "d",
+                    newValue : 9,
+                    oldValue : 10
+                }, {
+                    type : "new",
+                    name : "e",
+                    newValue : 9,
+                    oldValue : undefined
+                }, {
+                    type : "updated",
+                    name : "d",
+                    newValue : 8,
+                    oldValue : 9
+                }, {
+                    type : "new",
+                    name : "f",
+                    newValue : 9,
+                    oldValue : undefined
+                }, {
+                    type : "updated",
+                    name : "d",
+                    newValue : -2,
+                    oldValue : 8
+                }, {
+                    type : "new",
+                    name : "g",
+                    newValue : "ok",
+                    oldValue : undefined
+                }, {
+                    type : "new",
+                    name : "h",
+                    newValue : "ok",
+                    oldValue : undefined
+                }, {
+                    type : "deleted",
+                    name : "g",
+                    newValue : undefined,
+                    oldValue : "ok"
+                }, {
+                    type : "new",
+                    name : "i",
+                    newValue : 2,
+                    oldValue : undefined
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : 8,
+                    oldValue : 2
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : 4,
+                    oldValue : 8
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : 1,
+                    oldValue : 4
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : 16,
+                    oldValue : 1
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : 4,
+                    oldValue : 16
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : 1,
+                    oldValue : 4
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : -1,
+                    oldValue : 1
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : -2,
+                    oldValue : -1
+                }, {
+                    type : "updated",
+                    name : "i",
+                    newValue : -1,
+                    oldValue : -2
+                }];
+        var observer = function (chgList) {
+            assert.equal(chgList.length, 1);
+            var chg = chgList[0];
+            assert.strictEqual(chg.object, a1);
+            delete chg.object;
+            var item = expectedChgList.shift();
+            assert.deepEqual(chg, item);
+        };
+        json.observe(a1, observer);
+        myProcessedFunction(a1);
+        mySourceFunction(a2);
+        json.unobserve(a1, observer);
+        assert.deepEqual(a1, a2);
+        assert.equal(expectedChgList.length, 0);
+    });
+});


### PR DESCRIPTION
This pull request adds the transpiler.
The transpiler automatically does the following kinds of transformations in js code.

``` js
a.b = c; /* becomes */ $set(a, "b", c);
a.b += c; /* becomes */ $set.op(a,"b","+=",c); /* and the same for other assignment operators */
delete a.b; /* becomes */ $set.del(a, "b");
a.b++; /* becomes */ $set.inc(a, "b");
a.b--; /* becomes */ $set.dec(a, "b");
++a.b; /* becomes */ $set.op(a, "b","+=", 1);
--a.b; /* becomes */ $set.op(a, "b", "-=", 1);

/* And this is added at the beginning of the output: */ var $set = require("hsp/$set");
```

This pull request does not add any automatic call to the transpiler in the compiler (this will probably have to be done in another pull request, making sure the error handling is done consistently).
