### PR TITLE
clean-up folders structure - follow up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,3 @@ node_modules
 ._.DS_STORE
 dist
 sauce_connect.log
-build/hashspace.compiler.js
-build/hashspace.compiler.min.js
-build/hashspace.js
-build/hashspace.min.js
-build/tmp

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -152,7 +152,7 @@ module.exports = function (grunt) {
       fs_module: {
         files: [{
           src: 'hsp/compiler/hspblocks.pegjs',
-          dest: 'build/tmp/fs.js'
+          dest: 'dist/tmp/fs.js'
         }],
         options: {
           processContent: function (content, srcpath) {
@@ -164,7 +164,7 @@ module.exports = function (grunt) {
     browserify: {
       runtime: {
         files: {
-          'build/hashspace.js': ['hsp/rt.js']
+          'dist/hashspace.js': ['hsp/rt.js']
         },
         options: {
           aliasMappings: [
@@ -188,7 +188,7 @@ module.exports = function (grunt) {
       },
       compiler: {
         files: {
-          'build/hashspace.compiler.js': ['hsp/compiler/compiler.js']
+          'dist/hashspace.compiler.js': ['hsp/compiler/compiler.js']
         },
         options: {
           aliasMappings: [
@@ -200,7 +200,7 @@ module.exports = function (grunt) {
           ],
           shim: {
             fs: {
-              path: 'build/tmp/fs.js',
+              path: 'dist/tmp/fs.js',
               exports: null
             }
           }
@@ -210,8 +210,8 @@ module.exports = function (grunt) {
     uglify: {
       hsp: {
         files: {
-          'build/hashspace.min.js': ['build/hashspace.js'],
-          'build/hashspace.compiler.min.js': ['build/hashspace.compiler.js']
+          'dist/hashspace.min.js': ['dist/hashspace.js'],
+          'dist/hashspace.compiler.min.js': ['dist/hashspace.compiler.js']
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "karma-firefox-launcher": "~0.1.3"
   },
   "scripts": {
-    "test": "grunt test",
-    "prepublish": "grunt package"
+    "test": "grunt test"
   }
 }


### PR DESCRIPTION
Follow up on 83271ba87330342d5fb5ff0009d2b55378801621:
- use the `dist` folder for generated files
- remove dist files generation on each npm install / TravisCI build - for now we are not distributing those files so there is no need to generate them. 
