### PR TITLE
prepare proper publication in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+build
+dist
+public
+sauce_connect.log

--- a/build/grunt/config-checkStyle.js
+++ b/build/grunt/config-checkStyle.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
             options : {
                 "node" : true
             },
-            src : ['Gruntfile.js', 'build/grunt/*.*']
+            src : ['index.js', 'Gruntfile.js', 'build/grunt/*.*']
         },
         source : {
             src : ['hsp/**/*.js', '!hsp/utils/jquery*.min.js']

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  compiler: require('./hsp/compiler/compiler.js')
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "ariatemplates <contact@ariatemplates.com> (http://github.com/ariatemplates)",
-  "name": "hashspace-prototype",
-  "description": "hashspace runtime prototype",
+  "name": "hashspace",
+  "description": "hashspace compiler and runtime",
   "version": "0.0.1-SNAPSHOT",
   "homepage": "",
   "repository": {


### PR DESCRIPTION
Few changes we've discussed last week:
- change npm name from `hashspace-prototype` to `hashspace`
- ignore files that shouldn't be published in npm
- expose "public API" via index.js
