### PR TITLE
Fix #53 ObjectLiteral(s) are not supported yet

### DIFF
--- a/hsp/compiler/parser.js
+++ b/hsp/compiler/parser.js
@@ -769,6 +769,22 @@ var HExpression = klass({
                     r = "[" + code.join(",") + "].join(' ')";
                 }
                 break;
+            case "ObjectLiteral":
+                var properties = node.properties, size = properties.length, code = [];
+                for (var i = 0; size > i; i++) {
+                    code[i] = this._process(properties[i]);
+                }
+                if (size < 1) {
+                    r = '';
+                } else {
+                    r = "{" + code.join(",") + "}";
+                }
+                break;
+            case "PropertyAssignment":
+                var name = node.name, child = node.value;
+                var code = this._process(child);
+                r = name + ":" + code;
+                break;
             default :
                 this._logError(node.type + '(s) are not supported yet');
                 console.warn('[HExpression] ' + node.type + '(s) are not supported yet:');

--- a/public/test/compiler/samples/component7.txt
+++ b/public/test/compiler/samples/component7.txt
@@ -1,0 +1,16 @@
+##### Template:
+
+# template test(d)
+  <#lib.nbrfield objliteral="{{value: d.value, min: 10, max: "10", reset: notifyReset(123)}}"/>
+# /template
+
+##### Parsed Tree:
+"skip"
+
+##### Syntax Tree:
+"skip"
+
+##### Template Code:
+test=[
+  n.cpt([_lib,"lib","nbrfield"],{e1:[6,function(a0,a1) {return {value:a0,min:10,max:"10",reset:a1};},2,3],e2:[1,2,"d","value"],e3:[4,1,notifyReset,0,123]},{"objliteral":["",1]},0)
+]

--- a/public/test/compiler/tests.js
+++ b/public/test/compiler/tests.js
@@ -90,9 +90,8 @@ describe('Block Parser: ', function () {
     var samples = ["template1", "template2", "text1", "text2", "text3", "text5", "text6", "text7", "if1", "if2", "if3", "if4",
             "comment", "foreach1", "foreach2", "foreach3", "element1", "element2", "element3", "element4", "element5",
             "evthandler1", "evthandler2", "evthandler3", "component1", "component2", "component3", "component4",
-            "component5", "component6", "jsexpression1", "jsexpression2", "jsexpression3", "jsexpression4", "jsexpression5",
+            "component5", "component6", "component7", "jsexpression1", "jsexpression2", "jsexpression3", "jsexpression4", "jsexpression5",
             "class1", "class2", "class3", "class4", "insert1", "insert2"];
-    //samples=["component6"];
 
     for (var i = 0, sz = samples.length; sz > i; i++) {
         // create one test for each sample

--- a/public/test/rt/subtemplate.spec.hsp
+++ b/public/test/rt/subtemplate.spec.hsp
@@ -72,6 +72,15 @@ function concat(a,b) {
     <#field2 attributes="{d.attributes}"/>
 # /template
 
+# template field3(attributes)
+    Enter some text: 
+    <input type="text" value="{attributes.myvalue.value}"/>
+# /template
+
+# template test7(d)
+    <#field3 attributes="{{myvalue: d}}"/>
+# /template
+
 describe("Sub-template insertion", function () {
     it("tests a simple insertion", function () {
         var dm = {
@@ -241,6 +250,29 @@ describe("Sub-template insertion", function () {
         hsp.refresh();
 
         expect(input.value).to.equal("new text");
+        n.$dispose();
+    });
+
+    it("tests input data change with objectliteral argument", function () {
+        debugger;
+        var dm = {
+            value : "some text"
+        };
+        var n = test7(dm);
+
+        var input = n.node.childNodes[1];
+        expect(input.value).to.equal("some text");
+
+        // change the whole attributes object, which is a root
+        // element in the scope of the field2 template
+        json.set(dm, "value", "new text");
+        hsp.refresh();
+        expect(input.value).to.equal("new text");
+
+        input.value = "bar";
+        fireEvent("keydown",input);
+        expect(dm.value).to.equal("bar");
+
         n.$dispose();
     });
 });


### PR DESCRIPTION
The following template now works:

```
# template hello(config)
    <div class="msg">
        Hello {config.name}!
    </div>
# /template

# template main()
    <#hello config="{{name: 'World'}}"/>
# /template

// display the template in the #output div
main().render("output");
```
