### PR TITLE
Fix #52 IE8: inline style not working

### DIFF
--- a/hsp/rt/eltnode.js
+++ b/hsp/rt/eltnode.js
@@ -98,12 +98,12 @@ var EltNode = klass({
                     }
                 }
                 try {
-                  nd = doc.createElement('<' + this.tag + (nodeType?' type=' + nodeType : '') + ' name=' + nodeName + ' >');
+                  nd = doc.createElement('<' + this.tag + (nodeType?' type=' + nodeType : '') + (nodeName?' name=' + nodeName : '') + ' >');
                 }
                 catch (e) {
                     nd = doc.createElement(this.tag);
                     if (nodeType) nd.type = nodeType;
-                    nd.name = nodeName;
+                    if (nodeName) nd.name = nodeName;
                  }
             }
             else {

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,8 @@
 
 <html>
 <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title># hashspace</title>
 <script type="text/javascript" src="/lib/noder.min.js">
 {

--- a/public/test/rt/elt.spec.hsp
+++ b/public/test/rt/elt.spec.hsp
@@ -16,7 +16,8 @@
 
 var hsp=require("hsp/rt"),
     fireEvent=require("hsp/utils/eventgenerator").fireEvent,
-    json=require("hsp/json");
+    json=require("hsp/json"),
+    ht=require("hsp/utils/hashtester");
 
 
 # template test1(person)
@@ -42,6 +43,12 @@ var hsp=require("hsp/rt"),
 var globalObject={value:"foo"};
 # template test4()
     <input type="text" value="{globalObject.value}"/>
+# /template
+
+# template test5(name)
+    <div style="color:red;">
+        Hello {name}!
+    </div>
 # /template
 
 
@@ -132,6 +139,16 @@ describe("Element Nodes", function () {
         expect(n.node.firstChild.childNodes[1].attributes["class"].value).to.equal("");
         expect(n.node.firstChild.childNodes[1].firstChild.nodeValue).to.equal("Frequent flyer #:  ");
         expect(n.node.firstChild.childNodes[2].nodeValue).to.equal(" ] ");
+        n.$dispose();
+    });
+
+    it("tests the EltNode with an inline style", function() {
+        var n=test5();
+        var h=ht.newTestContext();
+        test5("World").render(h.container);
+        var div = h('div');
+
+        expect(div.$selection[0].style.color).to.equal("red");
         n.$dispose();
     });
 


### PR DESCRIPTION
In fact, it works fine in IE8 in  'IE8 Standards' mode. 
It doesn't work when either 'IE7 Standards' or Quirks modes is activated.

This PRs simply adds a test for inline style, and fixes the playground page to use 'IE8 Standards' mode by default in IE8. It also removes the useless `name=null` that were generated.
