### PR TITLE
auto-release framework builds from Travis CI to gh-pages => for review, do not merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - SAUCE_USERNAME=ariatemplates
     - SAUCE_ACCESS_KEY=620e638e-90d2-48e1-b66c-f9505dcb888b
+    - secure: MdntYCP5jCw2PZs/pRHbcLS0Ish8VUmK7EpTFXvhi7edyIUFLd/ivqlPBbD6iJCet1LhF2umVV1pc4ol6mmhAhP46aIjSwY7dFDB9T67DfNkA1c8Yk+FMZqU65o5oF84Y5W7TMlVVt6irbxEnJDr9NZi4LzvSiW3xXiz+onepOA=
 
 before_install:
  - npm install --quiet -g grunt-cli
@@ -17,3 +18,7 @@ before_script:
 
 script:
  - grunt ci
+
+after_success:
+ - chmod -R 777 ./ci-release.sh
+ - ./ci-release.sh

--- a/ci-release.sh
+++ b/ci-release.sh
@@ -1,0 +1,12 @@
+if [ $TRAVIS_PULL_REQUEST = "false" ]; then
+    # we need to clone the repo once again, as by default Travis CI makes
+    # shallow clones where gh-pages branch is not available and can't be fetched
+    git clone "https://github.com/${TRAVIS_REPO_SLUG}.git" temp && cd temp &&
+    git config user.email "releasebot@ariatemplates.com" &&
+    git config user.name "Release Bot" &&
+    git checkout -b gh-pages origin/gh-pages &&
+    cp -rf ../dist dist &&
+    git add -f dist &&
+    git commit -m "release ${TRAVIS_COMMIT}" &&
+    git push "https://${GH_CREDENTIALS}@github.com/${TRAVIS_REPO_SLUG}.git" gh-pages
+fi

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -14,6 +14,9 @@
  */
 
 module.exports = function (grunt) {
+
+  var pkg = require('./package.json');
+
   grunt.initConfig({
     mochaTest: {
       test: {
@@ -157,7 +160,7 @@ module.exports = function (grunt) {
       fs_module: {
         files: [{
           src: 'hsp/compiler/hspblocks.pegjs',
-          dest: 'dist/tmp/fs.js'
+          dest: 'dist/'+pkg.version+'/tmp/fs.js'
         }],
         options: {
           processContent: function (content, srcpath) {
@@ -168,9 +171,7 @@ module.exports = function (grunt) {
     },
     browserify: {
       runtime: {
-        files: {
-          'dist/hashspace.js': ['hsp/rt.js']
-        },
+        files: [{dest: 'dist/'+pkg.version+'/hashspace.js', src: ['hsp/rt.js']}],
         options: {
           aliasMappings: [
             {
@@ -192,9 +193,7 @@ module.exports = function (grunt) {
         }
       },
       compiler: {
-        files: {
-          'dist/hashspace.compiler.js': ['hsp/compiler/compiler.js']
-        },
+        files: [{dest: 'dist/'+pkg.version+'/hashspace.compiler.js', src: ['hsp/compiler/compiler.js']}],
         options: {
           aliasMappings: [
             {
@@ -205,7 +204,7 @@ module.exports = function (grunt) {
           ],
           shim: {
             fs: {
-              path: 'dist/tmp/fs.js',
+              path: 'dist/'+pkg.version+'/tmp/fs.js',
               exports: null
             }
           }
@@ -214,10 +213,10 @@ module.exports = function (grunt) {
     },
     uglify: {
       hsp: {
-        files: {
-          'dist/hashspace.min.js': ['dist/hashspace.js'],
-          'dist/hashspace.compiler.min.js': ['dist/hashspace.compiler.js']
-        }
+        files: [
+          {dest: 'dist/'+pkg.version+'/hashspace.min.js', src: ['dist/'+pkg.version+'/hashspace.js']},
+          {dest: 'dist/'+pkg.version+'/hashspace.compiler.min.js', src: ['dist/'+pkg.version+'/hashspace.compiler.js']}
+        ]
       }
     }
   });
@@ -228,6 +227,6 @@ module.exports = function (grunt) {
 
   grunt.registerTask('package', ['copy', 'browserify', 'uglify']);
   grunt.registerTask('test', ['checkStyle','mochaTest', 'karma:unit']);
-  grunt.registerTask('ci', ['checkStyle','mochaTest', 'karma:ci']);
+  grunt.registerTask('ci', ['checkStyle','mochaTest', 'karma:ci', 'package']);
   grunt.registerTask('default', ['hspserver','watch']);
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "express": "3.0.6",
     "request": "2.12.0",
     "grunt-mocha-test": "~0.7.0",
-    "grunt-browserify": "~1.3.0",
+    "grunt-browserify": "~2.0.0",
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-contrib-copy": "~0.4.1",
     "karma": "~0.11.12",


### PR DESCRIPTION
This is a first stab at making Travis CI making releases of browserify-built version of haspace. Here are the main ideas:
- each build on the Travis CI runs `package` phase to produce browserified version of compiler + runtime
- each build of the `master` branch will result in having build outcome being pushed to the `gh-pages` branch
- builds are copied to the following folders structure: `\dist\[version from package.json]`

This PR, when merged, would fail at the publish time since we need to create the detached `gh-pages` branch first. I will create & push this branch before merging but just wanted to get your early feedback. 

In any case, we should have a new release (snapshot or otherwise) published on the net 5 minutes after checkin. Pretty awesome, no?  
