### PR TITLE
Adding noder build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 ._.DS_STORE
 dist
 sauce_connect.log
+*.peg.js

--- a/build/grunt/config-checkStyle.js
+++ b/build/grunt/config-checkStyle.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
             src : ['index.js', 'Gruntfile.js', 'build/grunt/*.*']
         },
         source : {
-            src : ['hsp/**/*.js']
+            src : ['hsp/**/*.js', '!hsp/**/*.peg.js']
         },
         public : {
             files : {

--- a/build/grunt/hspserver.js
+++ b/build/grunt/hspserver.js
@@ -3,11 +3,10 @@ var app = express();
 var server = require('http').createServer(app);
 var path = require("path");
 
-var renderer = require("../../hsp/compiler/renderer");
-
-
 module.exports = function(grunt) {
     grunt.registerTask('hspserver', 'Start a web server to server compiled templates on the fly', function () {
+        var renderer = require("../../hsp/compiler/renderer");
+
         grunt.config.requires('hspserver.port');
         grunt.config.requires('hspserver.base');
         grunt.config.requires('hspserver.templateExtension');

--- a/build/karma-hsp-preprocessor/index.js
+++ b/build/karma-hsp-preprocessor/index.js
@@ -1,7 +1,5 @@
-var compiler = require("../../index").compiler;
-
 var createHspPreprocessor = function (args, config, logger, helper) {
-
+  var compiler = require("../../index").compiler;
   var log = logger.create('preprocessor.hsp');
 
   return function (content, file, done) {

--- a/hsp/compiler/parser.js
+++ b/hsp/compiler/parser.js
@@ -1,10 +1,5 @@
-var PEG = require("pegjs");
-var fs = require("fs");
-var grammar = fs.readFileSync(__dirname + "/hspblocks.pegjs", "utf-8");
 var klass = require("../klass");
-var blockParser = PEG.buildParser(grammar, {
-    trackLineAndColumn : true
-});
+var blockParser = require("./hspblocks.peg.js");
 
 //http://www.w3.org/TR/html-markup/syntax.html#syntax-elements
 var VOID_HTML_ELEMENTS = {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "acorn": "0.1.0",
-    "pegjs": "0.7.0",
     "uglify-js": "2.4.11"
   },
   "devDependencies": {
@@ -24,7 +23,8 @@
     "grunt-mocha-test": "~0.7.0",
     "grunt-browserify": "~2.0.0",
     "grunt-contrib-uglify": "~0.2.7",
-    "grunt-contrib-copy": "~0.4.1",
+    "grunt-peg": "~1.0.0",
+    "atpackager": "~0.2.2",
     "karma": "~0.11.12",
     "grunt-karma": "~0.7.2",
     "karma-commonjs": "0.0.6",
@@ -40,6 +40,7 @@
     "jquery": "~1.11.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "prepublish": "grunt prepublish"
   }
 }


### PR DESCRIPTION
This pull request adds a noder build in addition to the browserify build.
The generated files do not include noder itself, but depend on it.

Once integrated, it can be used in the following way:
- For the runtime:

``` html
<script type="text/javascript" src="http://noder-js.ariatemplates.com/dist/master/noder.js"></script>
<script type="text/javascript" src="http://hashspace.ariatemplates.com/dist/0.0.1-SNAPSHOT/hashspace-noder.js"></script>
<script type="noder">
var main = require('main.hsp.js');
main({name:"world"}).render('out');
</script>
```
- For both the runtime and compiler:

``` html
<script type="text/javascript" src="http://noder-js.ariatemplates.com/dist/master/noder.js"></script>
<script type="text/javascript" src="http://hashspace.ariatemplates.com/dist/0.0.1-SNAPSHOT/hashspace-noder.js"></script>
<script type="text/javascript" src="http://hashspace.ariatemplates.com/dist/0.0.1-SNAPSHOT/hashspace-compiler-noder.js"></script>
<script type="hashspace" id="mainHsp">
# template main(data)
   Hello {data.name}!
# /template
main({name:"world"}).render('out');
</script>
<script type="noder">
var compiler = require('hsp/compiler/compiler');
var res = compiler.compile(document.getElementById("mainHsp").innerHTML,"main.hsp");
noder.execute(res.code, "main.hsp.js").end();
</script>
```
