### PR TITLE
Extend white space support for class attributes

### DIFF
--- a/hsp/compiler/hspblocks.pegjs
+++ b/hsp/compiler/hspblocks.pegjs
@@ -221,7 +221,7 @@ LogBlock
   }
 
 ExpressionBlock
-  = "{" ubflag:":"? e:HExpression* "}" // keep a list of expression to match expressions starting with a valid part
+  = "{" ubflag:":"? __ e:HExpression* "}" // keep a list of expression to match expressions starting with a valid part
   {
     var r={};
     if (e.length==1) {
@@ -272,8 +272,8 @@ ExpressionBlock
 HExpression
   =   HExpressionCssClassElt 
     / HExpressionContent 
-    / "," __ cce:HExpressionCssClassElt {return cce}
-    / "," __ exp:HExpressionContent {return exp}
+    / "," __ cce:HExpressionCssClassElt __ {return cce}
+    / "," __ exp:HExpressionContent __ {return exp}
     / InvalidExpressionValue
 
 HExpressionContent

--- a/public/test/compiler/samples/class5.txt
+++ b/public/test/compiler/samples/class5.txt
@@ -1,0 +1,36 @@
+##### Template:
+# template test(msg)
+	<div class="{ 'one',
+        'two':msg.isTrue }">
+    foo
+  </div>
+  <div class="{
+    'one',
+    'two':msg.isTrue
+  }">
+    foo
+  </div>
+# /template
+
+##### Parsed Tree
+"skip"
+
+##### Syntax Tree
+"skip"
+
+##### Template Code
+test=[
+    n.elt(
+        "div",
+        {e1:[6,function(a0) {return ["one",((a0)? ''+"two":'')].join(' ');},2],e2:[1,2,"msg","isTrue"]},
+        {"class":["",1]},
+        0,
+        [n.$text(0,["foo "])]
+    ),n.elt(
+        "div",
+        {e1:[6,function(a0) {return ["one",((a0)? ''+"two":'')].join(' ');},2],e2:[1,2,"msg","isTrue"]},
+        {"class":["",1]},
+        0,
+        [n.$text(0,["foo "])]
+    )
+]

--- a/public/test/compiler/tests.js
+++ b/public/test/compiler/tests.js
@@ -91,8 +91,8 @@ describe('Block Parser: ', function () {
             "comment", "foreach1", "foreach2", "foreach3", "element1", "element2", "element3", "element4", "element5",
             "evthandler1", "evthandler2", "evthandler3", "component1", "component2", "component3", "component4",
             "component5", "component6", "component7", "jsexpression1", "jsexpression2", "jsexpression3", "jsexpression4", "jsexpression5",
-            "class1", "class2", "class3", "class4", "insert1", "insert2", "log1", "log2"];
-    //samples=["log2"];
+            "class1", "class2", "class3", "class4", "class5", "insert1", "insert2", "log1", "log2"];
+    //samples=["class5"];
 
     for (var i = 0, sz = samples.length; sz > i; i++) {
         // create one test for each sample


### PR DESCRIPTION
This is a quick fix for issue #69 to support additional white spaces/carriage returns at the beginning and end of a css class expression.
