### PR TITLE
automatically load sample names for the compiler tests

### DIFF
--- a/public/test/compiler/errtests.js
+++ b/public/test/compiler/errtests.js
@@ -20,11 +20,9 @@ describe('Template compilation errors: ', function () {
         }
     };
 
-    var samples = ["text1", "text2", "text3", "if1", "if2", "if3", "if4", "if5", "if6", "if7", "foreach1", "foreach2",
-            "foreach3", "element1", "element2", "element3", "element4", "element5", "element6", "element7", "element8",
-            "insert", "template1", "template2", "template3", "template4", "template5", "template6", "template7",
-            "jsexpression1", "jsexpression2", "component1", "component2"];
+    var samples = ut.getSampleNames(__dirname + "/errsamples");
     //samples=["component2"];
+
     for (var i = 0, sz = samples.length; sz > i; i++) {
         // create one test for each sample
         it('tests error sample ('+samples[i]+')', testFn.bind({

--- a/public/test/compiler/tests.js
+++ b/public/test/compiler/tests.js
@@ -87,11 +87,7 @@ describe('Block Parser: ', function () {
         }
     };
 
-    var samples = ["template1", "template2", "text1", "text2", "text3", "text5", "text6", "text7", "if1", "if2", "if3", "if4",
-            "comment", "foreach1", "foreach2", "foreach3", "element1", "element2", "element3", "element4", "element5",
-            "evthandler1", "evthandler2", "evthandler3", "component1", "component2", "component3", "component4",
-            "component5", "component6", "component7", "jsexpression1", "jsexpression2", "jsexpression3", "jsexpression4", "jsexpression5",
-            "class1", "class2", "class3", "class4", "insert1", "insert2", "log1", "log2"];
+    var samples = ut.getSampleNames(__dirname + "/samples");
     //samples=["log2"];
 
     for (var i = 0, sz = samples.length; sz > i; i++) {

--- a/public/test/compiler/utils/testutils.js
+++ b/public/test/compiler/utils/testutils.js
@@ -1,4 +1,5 @@
 var fs = require("fs");
+var path = require("path");
 
 /**
  * Return the template part of a template sample
@@ -25,6 +26,12 @@ exports.getSampleContent = function (sampleName) {
         codeFragments : cf
     };
     return res;
+};
+
+exports.getSampleNames = function (dir) {
+  return fs.readdirSync(dir).map(function(fileName){
+    return path.basename(fileName, '.txt');
+  });
 };
 
 /**


### PR DESCRIPTION
During the last Friday presentation I've noticed that names of samples / err samples used for compiler test needs to be specified "by hand", so here is the automated version. The side effect of this automation is that it revealed that some of samples weren't used during the build and as such the build is failing with this change. 

The question is: as those legitimate failures?  Or maybe those samples are not relevant any more? 
