### PR TITLE
fix: allow whitespaces before # template

### DIFF
--- a/hsp/compiler/parser/hspblocks.pegjs
+++ b/hsp/compiler/parser/hspblocks.pegjs
@@ -13,7 +13,7 @@ TemplateFile
   {return blocks;}
 
 TextBlock
-  = lines:(!("#" _ "template") !("#" _ [a-zA-Z0-9]+ _ "template") !("#" _ "require") chars:[^\n\r]* eol:EOL {return chars.join("")+eol})+ 
+  = lines:(!(_ "#" _ "template") !(_ "#" _ [a-zA-Z0-9]+ _ "template") !("#" _ "require") chars:[^\n\r]* eol:EOL {return chars.join("")+eol})+
   {return {type:"plaintext", value:lines.join('')}}
 
 RequireBlock "require block" // TODO: finalize!

--- a/public/test/compiler/tests.js
+++ b/public/test/compiler/tests.js
@@ -106,6 +106,21 @@ describe('Block Parser: ', function () {
       assert.equal(r.errors.length, 0, "no compilation error");
     });
 
+    it('should allow whitespaces before #template', function(){
+      var r = compiler.compile(
+        '\n   #template spacesBefore()\n' +
+        ' #/template', "spacesBefore");
+      assert.equal(r.errors.length, 0, "no compilation error");
+    });
+
+    it('should allow whitespaces before #template when a modifier is present', function(){
+        var r = compiler.compile(
+            '\n   # export  template spacesBefore()\n' +
+                ' #/template', "spacesBefore");
+        console.log(r.errors);
+        assert.equal(r.errors.length, 0, "no compilation error");
+    });
+
     it('validates full compiled template', function () {
         var sample = ut.getSampleContent("template1");
         var r = compiler.compile(sample.template, "template1");


### PR DESCRIPTION
Fixes #89

While this fixes the issue reported in #89 looking at the peg grammar made me realize that there are some other cases where it is not fixed. The trouble is, though, that I'm not sure if those other cases are used. I'm talking about this rule: `"#" _ [a-zA-Z0-9]+ _ "template"`, not sure what this one stands for. From reading code it sounds like a plan for supporting template modifiers, not sure if this is fully implemented, though. @b-laporte could you shed some light?
