### PR TITLE
fix: properly handle boolean attributes

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -180,14 +180,14 @@ module.exports = function (grunt) {
         transports: ['xhr-polling'],
         singleRun: true,
         browserNoActivityTimeout: 20000,
-        captureTimeout: 120000,
+        captureTimeout: 180000,
         browsers: ['SL_IE_8', 'SL_IE_9', 'SL_IE_10', 'SL_IE_11', 'SL_Safari_6', 'SL_Safari_7', 'SL_Firefox', 'SL_Chrome', 'ANDROID'],
         reporters: ['dots', 'saucelabs']
       },
       sauce: {
         singleRun: true,
         browserNoActivityTimeout: 20000,
-        captureTimeout: 120000,
+        captureTimeout: 180000,
         browsers: ['SL_IE_8', 'SL_IE_9', 'SL_IE_10', 'SL_IE_11', 'SL_Safari_6', 'SL_Safari_7', 'SL_Firefox', 'SL_Chrome', 'ANDROID'],
         reporters: ['dots', 'saucelabs']
       }

--- a/hsp/rt/eltnode.js
+++ b/hsp/rt/eltnode.js
@@ -21,6 +21,28 @@ var TNode = require("./tnode").TNode;
 var hsp = require("../rt");
 var gestures = require("../gestures/gestures");
 
+var booleanAttributes = {
+    async: true,
+    autofocus: true,
+    autoplay: true,
+    controls: true,
+    defer: true,
+    disabled: true,
+    hidden: true,
+    ismap: true,
+    loop: true,
+    multiple: true,
+    open: true,
+    readonly: true,
+    required: true,
+    scoped: true,
+    selected: true
+};
+
+function isBooleanAttribute(attrName) {
+    return booleanAttributes.hasOwnProperty(attrName);
+}
+
 /**
  * Generic element node Add attribute support on top of TNode - used for div, spans, ul, li, h1, etc
  */
@@ -239,6 +261,11 @@ var EltNode = klass({
                 if (nm === "model") {
                     // this is an hashspace extension attribute
                     continue;
+                } else if (isBooleanAttribute(nm)) {
+                    //this is equivalent to calling sth like: node.required = truthy / falsy;
+                    //a browser will remove this attribute if a provided value is falsy
+                    //http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attributes
+                    nd[nm] = att.getValue(eh, vs, "");
                 } else if (nm === "class") {
                     // issue on IE8 with the class attribute?
                     if (this.nodeNS) {

--- a/public/test/rt/booleanAttributes.spec.hsp
+++ b/public/test/rt/booleanAttributes.spec.hsp
@@ -1,0 +1,23 @@
+var json=require("hsp/json");
+hsp=require("hsp/rt");
+
+#template tpl(model)
+<input type = "text" required = "{model.flag}">
+# /template
+
+describe('boolean attributes', function () {
+
+    it('should add / remove boolean attributes with truthy / falsy values', function () {
+        var model = {flag: true};
+        var n = tpl(model);
+
+        expect(n.node.firstChild.required).to.equal(true);
+
+        // test property change
+        json.set(model, "flag", false);
+        hsp.refresh();
+        expect(n.node.firstChild.required).to.equal(false);
+
+        n.$dispose();
+    });
+});


### PR DESCRIPTION
Fixes #37

This is my first stab at fixing #37 - don't think it is complete fix at this point, but pushing code to start discussion on this item. More specifically I'm not sure if:
- we should be checking a type of a node on which a given attribute is used
- which attributes we should be taking into account - some of those attributes should probably cooperate with the `model` attribute to provide code validation...
