### PR TITLE
build: introduce jscs checks infrastructure

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,5 @@
+{
+    "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
+    "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+    "disallowYodaConditions": true
+}

--- a/.jscs.json.todo
+++ b/.jscs.json.todo
@@ -1,0 +1,41 @@
+{
+    "maximumLineLength": 140,
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "requireDotNotation": true,
+    "requireLeftStickedOperators": [","],
+    "requireSpaceAfterBinaryOperators": [
+            "+",
+            "-",
+            "/",
+            "*",
+            "=",
+            "==",
+            "===",
+            "!=",
+            "!=="
+        ],
+    "requireCapitalizedConstructors": true,
+    "safeContextKeyword": "self",
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch",
+        "case",
+        "default"
+    ],
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "return",
+        "try",
+        "catch"
+    ]
+}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -147,6 +147,12 @@ module.exports = function (grunt) {
         reporters: ['dots', 'saucelabs']
       }
     },
+    jscs: {
+        src: ['hsp/**/*.js', 'public/**/*.js', '!public/**/markdown.js'],
+        options: {
+            config: '.jscs.json'
+        }
+    },
     hspserver: {
       port: 8000,
       base: __dirname,
@@ -258,7 +264,7 @@ module.exports = function (grunt) {
   grunt.registerTask('prepublish', ['peg']);
   grunt.registerTask('package', ['prepublish', 'browserify', 'atpackager', 'uglify']);
   grunt.registerTask('mocha', ['peg', 'mochaTest']);
-  grunt.registerTask('test', ['checkStyle', 'mocha', 'karma:unit']);
-  grunt.registerTask('ci', ['checkStyle', 'mocha', 'karma:ci', 'package']);
+  grunt.registerTask('test', ['checkStyle', 'jscs', 'mocha', 'karma:unit']);
+  grunt.registerTask('ci', ['checkStyle', 'jscs', 'mocha', 'karma:ci', 'package']);
   grunt.registerTask('default', ['hspserver']);
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "load-grunt-tasks": "~0.2.1",
     "expect.js": "0.2.0",
     "noder-js": "~1.2.0",
-    "jquery": "~1.11.0"
+    "jquery": "~1.11.0",
+    "grunt-jscs-checker": "~0.4.0"
   },
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
A first attempt at introducing some coding guidelines (see #57) based on jscs checks. While playing with this PR it was clear that we don't have uniform coding guidelines at this point as most of jscs validations were failing ;-)

I'm sending this PR to start discussion on how to introduce stricter coding guidelines. One approach is to go over all the options and decide which ones we want to turn on. Other approach is to simply get coding style from the current aria templates and automate checks of those rules (probably a better way of moving forward, but even then we need to sync on PRs and introduce checks after merging all the PRs in progress).
