### PR TITLE
fixes #26

### DIFF
--- a/hsp/rt/$if.js
+++ b/hsp/rt/$if.js
@@ -130,12 +130,9 @@ var $IfNode = klass({
         if (cond !== this.lastConditionValue) {
             this.createChildNodeInstances(cond);
             this.root.updateObjectObservers(this);
-            this.adirty = false;
             this.cdirty = false;
-        } else {
-            // default behaviour
-            TNode.refresh.call(this);
         }
+        TNode.refresh.call(this);
     },
 
     /**

--- a/hsp/rt/$root.js
+++ b/hsp/rt/$root.js
@@ -426,7 +426,6 @@ var $InsertNode = klass({
                 // is JS function
                 this.node.nodeValue = this.getContent();
             }
-            this.adirty = false;
         }
         TNode.refresh.call(this);
     }

--- a/hsp/rt/cptcomponent.js
+++ b/hsp/rt/cptcomponent.js
@@ -484,7 +484,6 @@ exports.$CptComponent = {
   refreshAttributes : function () {
     var atts = this.atts, att, ctlAtt, eh = this.eh, ctl = this.controller, v;
     var vs = this.isCptAttElement? this.vscope : this.parent.vscope;
-    this.adirty = false;
     if (atts && ctl && ctl.attributes) {
       // this template has a controller
       // let's propagate the new attribute values to the controller attributes

--- a/hsp/rt/cpttemplate.js
+++ b/hsp/rt/cpttemplate.js
@@ -86,7 +86,6 @@ module.exports.$CptTemplate = {
    */
   refreshAttributes : function () {
       var atts = this.atts, att, eh = this.eh, pvs = this.parent.vscope;
-      this.adirty = false;
       if (atts) {
           // this template has no controller
           // let's propagate the new attribute values to the current scope

--- a/hsp/rt/eltnode.js
+++ b/hsp/rt/eltnode.js
@@ -224,8 +224,6 @@ var EltNode = klass({
      */
     refreshAttributes : function () {
         var nd = this.node, atts = this.atts, att, eh = this.eh, vs = this.vscope, nm, modelRefs = null;
-        this.adirty = false;
-
         if (atts) {
             for (var i = 0, sz = this.atts.length; sz > i; i++) {
                 att = atts[i];

--- a/hsp/rt/tnode.js
+++ b/hsp/rt/tnode.js
@@ -202,7 +202,7 @@ var TNode = klass({
         if (this.adirty) {
             // update observable pairs
             this.root.updateObjectObservers(this);
-            this.adirty=false;
+            this.adirty = false; // adirty should not be set to false anywhere else unless updateObjectObservers is not required
         }
         if (this.cdirty) {
             var cn = this.childNodes;

--- a/hsp/utils/hashtester.js
+++ b/hsp/utils/hashtester.js
@@ -150,5 +150,8 @@ module.exports.newTestContext = function() {
     h.logs.clear=function() {
         logs=[];
     };
+    h.refresh=function() {
+        hsp.refresh();
+    };
     return h;
 };

--- a/public/test/rt/exprbinding.spec.hsp
+++ b/public/test/rt/exprbinding.spec.hsp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var $set=require("hsp/$set"),
+    ht=require("hsp/utils/hashtester");
+
+function changeValueAndObject (data,val) {
+    $set(data,"object",{value:val})
+}
+
+function changeValue (data,val) {
+    $set(data.object,"value",val);
+}
+
+# template test1(data) 
+    <input class="in1" type="text" value="{data.object.value}" />
+    <input class="in2" type="text" value="{data.object.value}" />
+# /template
+
+describe("Expression Bindings", function () {
+    var INPUT1=".in1", INPUT2=".in2";
+
+    it("validates bindings with value change", function() {
+        var h=ht.newTestContext(), dm={object:{value:"initial value"}};
+        test1(dm).render(h.container);
+
+        expect(h(INPUT1).value()).to.equal("initial value");
+        expect(h(INPUT2).value()).to.equal("initial value");
+
+        changeValue(dm,"v1");
+        h.refresh();
+
+        expect(h(INPUT1).value()).to.equal("v1");
+        expect(h(INPUT2).value()).to.equal("v1");
+
+        h.$dispose();
+    });
+
+    it("validates bindings with path change", function() {
+        var h=ht.newTestContext(), dm={object:{value:"initial value"}};
+        test1(dm).render(h.container);
+
+        changeValueAndObject(dm,"v1");
+        h.refresh();
+
+        expect(h(INPUT1).value()).to.equal("v1");
+        expect(h(INPUT2).value()).to.equal("v1");
+
+        changeValue(dm,"v2");
+        h.refresh();
+
+        expect(h(INPUT1).value()).to.equal("v2");
+        expect(h(INPUT2).value()).to.equal("v2");
+
+        changeValueAndObject(dm,"v3");
+        h.refresh();
+
+        expect(h(INPUT1).value()).to.equal("v3");
+        expect(h(INPUT2).value()).to.equal("v3");
+
+        h.$dispose();
+    });
+});

--- a/public/test/rt/index.html
+++ b/public/test/rt/index.html
@@ -61,6 +61,7 @@
 	require("test/rt/cptattelements4.spec.hsp");
 	require("test/rt/log.spec.hsp");
 	require("test/rt/let.spec.hsp");
+	require("test/rt/exprbinding.spec.hsp");
 	require("test/gestures/touchEvent.spec.js");
 	require("test/gestures/tap.spec.hsp");
 	require("test/gestures/longPress.spec.hsp");


### PR DESCRIPTION
Well my last PR mostly fixed #26 - now it is done.
For those interested, the root cause was that the _updateObjectObservers()_ method was not called in some  cases from TNode.refresh() - as some child classes used to set the adirty attribute to false before the TNode.refresh() function was called..
