### PR TITLE
extend function expressions to observe function ctxt

### DIFF
--- a/hsp/rt/exphandler.js
+++ b/hsp/rt/exphandler.js
@@ -282,8 +282,10 @@ var FuncRefExpr = klass({
      * @param {Array} desc the expression descriptor - e.g. [1,2,"person","getDetails",0,"arg1"]
      */
     $constructor : function (desc) {
+        var etype = desc[0];
         // call parent constructor
         DataRefExpr.$constructor.call(this, desc);
+        this.bound = (etype === 3); // literal data ref are considered unbound
         var argIdx = desc[1] + 2;
         if (desc.length > argIdx) {
             this.args = desc.slice(argIdx);
@@ -391,8 +393,11 @@ var FuncRefExpr = klass({
         // call the parent method for the method root
         var r = DataRefExpr.getObservablePairs.call(this, eh, vscope);
 
-        // get the observable pairs for each of the function arguments
-
+        // add a new pair to observe the object corresponding to the 'this' context of the function
+        if (this.bound && r && r.length>1) {
+            var sz=r.length;
+            r.push([r[sz-1][0],null]);
+        }
         return r;
     }
 });

--- a/hsp/utils/hashtester.js
+++ b/hsp/utils/hashtester.js
@@ -93,6 +93,17 @@ var SelectionWrapper=klass({
         return this.$selection[0].value;
     },
     /**
+     * Return the value of an attribute of the node selected (only works on single-element selections)
+     * @param {String} attName the name of the attribute - e.g. "title"
+     */
+    attribute:function(attName) {
+        if (this.length!==1) {
+            throw new HtException(1,"[hashtester] attribute() method can only be called on single-element selections");
+        }
+        // TODO support textarea
+        return this.$selection[0][attName];
+    },
+    /**
      * Tells if the first element in the selection is assigned a given CSS class
      * @param {String} cssClassName the class name to check
      **/

--- a/public/test/rt/fnexpressions.spec.hsp
+++ b/public/test/rt/fnexpressions.spec.hsp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var ht=require("hsp/utils/hashtester");
+
+function concat(a,b) {
+    return "["+a+" "+b+"]";
+}
+
+# template test1(d)
+    <div class="content" title="{d.fn(d.msg1,d.msg2)}">foo</div>
+# /template
+
+# template test2(d)
+    <div class="content" title="{concat(d.msg1,d.msg2)}!">foo</div>
+# /template
+
+# template test3(d)
+    <div class="content" title="{d.sub.fn(d.msg1,d.msg2)}">foo</div>
+# /template
+
+describe("Function expressions", function () {
+    var C=".content";
+
+    it("validates attribute updates on arg changes (in-scope fn)", function() {
+        var h=ht.newTestContext(), d={
+            msg1:"hello",
+            msg2:"world",
+            fn:function(a,b) {
+                return "["+a+" "+b+"]";
+            }
+        };
+        test1(d).render(h.container);
+
+        expect(h(C).attribute("title")).to.equal("[hello world]");
+
+        // change arg
+        h.$set(d,"msg2","earth");
+
+        expect(h(C).attribute("title")).to.equal("[hello earth]");
+        h.$dispose();
+    });
+
+    it("validates attribute updates on arg changes (global fn)", function() {
+        var h=ht.newTestContext(), d={
+            msg1:"hello",
+            msg2:"world",
+            fn:function(a,b) {
+                return "["+a+" "+b+"]";
+            }
+        };
+        test2(d).render(h.container);
+
+        expect(h(C).attribute("title")).to.equal("[hello world]!");
+
+        // change arg
+        h.$set(d,"msg2","earth");
+
+        expect(h(C).attribute("title")).to.equal("[hello earth]!");
+        h.$dispose();
+    });
+
+    it("validates attribute updates on path changes (in-scope fn)", function() {
+        var h=ht.newTestContext(), d={
+            msg1:"hello",
+            msg2:"world",
+            sub:{
+                fn:function(a,b) {
+                    return "["+a+" "+b+"]";
+                }
+            }
+        };
+        test3(d).render(h.container);
+
+        expect(h(C).attribute("title")).to.equal("[hello world]");
+
+        // change path
+        h.$set(d,"sub",{
+            fn:function(a,b) {
+                return a+"-"+b;
+            }
+        });
+
+        expect(h(C).attribute("title")).to.equal("hello-world");
+
+        // change again
+        h.$set(d.sub,"fn",function(a,b) {
+            return a+"+"+b;
+        });
+
+        expect(h(C).attribute("title")).to.equal("hello+world");
+
+        h.$dispose();
+    });
+
+    it("validates attribute updates on changes in function 'this' (in-scope fn)", function() {
+        var h=ht.newTestContext(), d={
+            msg1:"hello",
+            msg2:"world",
+            sub:{
+                separator:"-",
+                fn:function(a,b) {
+                    return "["+a+this.separator+b+"]";
+                }
+            }
+        };
+        test3(d).render(h.container);
+
+        expect(h(C).attribute("title")).to.equal("[hello-world]");
+
+        // change context
+        h.$set(d.sub,"separator","+");
+
+        expect(h(C).attribute("title")).to.equal("[hello+world]");        
+
+        h.$dispose();
+    });
+});

--- a/public/test/rt/index.html
+++ b/public/test/rt/index.html
@@ -62,6 +62,7 @@
 	require("test/rt/log.spec.hsp");
 	require("test/rt/let.spec.hsp");
 	require("test/rt/exprbinding.spec.hsp");
+	require("test/rt/fnexpressions.spec.hsp");
 	require("test/gestures/touchEvent.spec.js");
 	require("test/gestures/tap.spec.hsp");
 	require("test/gestures/longPress.spec.hsp");


### PR DESCRIPTION
This PR extends the function expression support in order to automatically re-calculate the function value when one of the property of the function context changes (i.e. any change on the 'this' object).
Of course the function expression also observes the function arguments and the function path.

NB: this PR only concerns function expressions used in element attributes. To support the function expressions in text node, we need to remove the _insert_ node implementation (which are not used any longer as they have been replaced by components). As this may touch more files (compiler + runtime), I will do this in a separate PR when my 2 current PRs are integrated.
