### PR TITLE
update subtemplate changes bubbling - fixes #109

### DIFF
--- a/hsp/rt/$root.js
+++ b/hsp/rt/$root.js
@@ -461,7 +461,7 @@ var $CptNode = klass({
      */
     onAttributeChange : function (change) {
         var expIdx = -1;
-        // set the new attribute value in the parent scope to propagate change
+        // set the new attribute value in the parent vscope to propagate change
         var cfg = this.attcfg[change.name]; // change.name is the property name
         if (cfg && cfg.constructor === Array && cfg.length === 2 && cfg[0] === "") {
             // cfg is a text concatenation with an empty prefix - so 2nd element is the expression index
@@ -469,9 +469,14 @@ var $CptNode = klass({
         }
 
         if (expIdx > -1) {
-            var exp = this.eh.getExpr(expIdx);
+            var exp = this.eh.getExpr(expIdx), pvs=this.parent.vscope;
             if (exp.bound && exp.setValue) {
-                exp.setValue(this.parent.vscope, change.newValue);
+                var cv=exp.getValue(pvs,this.eh);
+                if (cv!==change.newValue) {
+                    // if current value is different, we update it on the scope object that owns it
+                    var vs=this.parent.getScopeOwner(exp.path[0],pvs);
+                    exp.setValue(vs, change.newValue);
+                }
             }
         }
     },

--- a/public/test/rt/index.html
+++ b/public/test/rt/index.html
@@ -55,6 +55,7 @@
 	require("test/rt/cptintegration.spec.hsp");
 	require("test/rt/subtemplates1.spec.hsp");
 	require("test/rt/subtemplates2.spec.hsp");
+	require("test/rt/subtemplates3.spec.hsp");
 	require("test/rt/cptattelements1.spec.hsp");
 	require("test/rt/cptattelements2.spec.hsp");
 	require("test/rt/cptattelements3.spec.hsp");

--- a/public/test/rt/subtemplates3.spec.hsp
+++ b/public/test/rt/subtemplates3.spec.hsp
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var ht=require("hsp/utils/hashtester");
+
+var count = 0;
+var addItem = function (items) {
+   count++;
+   items.push({name:"item"+count, edit:true});
+};
+
+var removeItem = function (items, index) {
+   items.splice(index, 1);
+};
+
+# template displayItem(itms, idx)
+    <li onclick="{removeItem(itms, 0)}">Remove #{idx}</li>
+# /template
+
+# template list(items)
+    <ul>
+        {foreach index,curItem in items}
+            {if true}
+                // if node is necessary to create a sub-scope
+                <#displayItem itms="{items}" idx="{index}"/>
+            {/if}
+        {/foreach}
+    </ul>
+    <a onclick="{addItem(items)}">Add item</a>
+# /template
+
+
+describe("Sub- and parent- template scope interactions", function () {
+    it("validates property bubbling from sub-template to parent", function() {
+        var h=ht.newTestContext();
+        var items = [];
+        addItem(items);
+        addItem(items);
+        addItem(items);
+
+        list(items).render(h.container);
+
+        expect(h("li").length).to.equal(3);
+        expect(h("li").item(0).text()).to.equal("Remove #0");
+        
+        h("li").item(0).click();
+        expect(h("li").length).to.equal(2);
+        expect(h("li").item(0).text()).to.equal("Remove #0");
+
+        h("li").item(0).click();
+        expect(h("li").length).to.equal(1);
+        // the following assertion will fail if property changes are not properly bubbled
+        expect(h("li").item(0).text()).to.equal("Remove #0");
+        
+        h.$dispose();
+    });
+});
+


### PR DESCRIPTION
Fix for issue #109
This issue was actually introduced with the new sub-scopes introduced with the {let} statement. In the sample provided with #109, the {if} statement is creating a sub-scope, and the sub-template property bubbling mechanism was creating a property in the wrong scope (in this example an _index_ property was created in the {if} scope and was hiding the _index_ property of the {foreach} item)

PS: the sub-template property bubbling mechanism is used to bubble scope changes from a sub-template to its parent template. This is necessary for instance when the sub-template contains _input_ elements that can change sub-template scope variables that should be then updated in the parent data model.
