### PR TITLE
adds Saucelabs badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 ._.DS_STORE
 dist
 sauce_connect.log
+sc.log
 *.peg.js
 test-results

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![Build Status](https://secure.travis-ci.org/ariatemplates/hashspace.png)](http://travis-ci.org/ariatemplates/hashspace)
 [![devDependency Status](https://david-dm.org/ariatemplates/hashspace/status.png?branch=master)](https://david-dm.org/ariatemplates/hashspace#info=dependencies)
 [![devDependency Status](https://david-dm.org/ariatemplates/hashspace/dev-status.png?branch=master)](https://david-dm.org/ariatemplates/hashspace#info=devDependencies)
-[![Coverage Status](https://coveralls.io/repos/ariatemplates/hashspace/badge.png?branch=master)](https://coveralls.io/r/ariatemplates/hashspace?branch=master)
+[![Coverage Status](https://coveralls.io/repos/ariatemplates/hashspace/badge.png?branch=master)](https://coveralls.io/r/ariatemplates/hashspace?branch=master)  
+[![Selenium Test Status](https://saucelabs.com/browser-matrix/hashspace.svg)](https://saucelabs.com/u/hashspace)
 
 hashspace
 =========

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -191,7 +191,7 @@ module.exports = function (grunt) {
           dir : 'test-results/karma/'
         }
       },
-      ci: {
+      ci1: {
         sauceLabs: {
           startConnect: false,
           tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
@@ -200,7 +200,19 @@ module.exports = function (grunt) {
         singleRun: true,
         browserNoActivityTimeout: 20000,
         captureTimeout: 300000,
-        browsers: ['SL_IE_8', 'SL_IE_9', 'SL_IE_10', 'SL_IE_11', 'SL_Safari_6', 'SL_Safari_7', 'SL_Firefox', 'SL_Chrome', 'SL_Android_4.0', 'SL_Android_4.1', 'SL_Android_4.2', 'SL_Android_4.3', 'SL_iOS_7'],
+        browsers: ['SL_Chrome', 'SL_Android_4.0', 'SL_Android_4.1', 'SL_IE_8', 'SL_IE_9', 'SL_Safari_7'],
+        reporters: ['dots', 'saucelabs']
+      },
+      ci2: {
+        sauceLabs: {
+          startConnect: false,
+          tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
+        },
+        transports: ['xhr-polling'],
+        singleRun: true,
+        browserNoActivityTimeout: 20000,
+        captureTimeout: 300000,
+        browsers: ['SL_iOS_7', 'SL_Firefox', 'SL_Android_4.2', 'SL_Android_4.3', 'SL_IE_10', 'SL_IE_11', 'SL_Safari_6'],
         reporters: ['dots', 'saucelabs']
       },
       sauce: {
@@ -329,6 +341,6 @@ module.exports = function (grunt) {
   grunt.registerTask('package', ['prepublish', 'browserify', 'atpackager', 'uglify']);
   grunt.registerTask('mocha', ['peg', 'inittests', 'mochaTest', 'finalizetests']);
   grunt.registerTask('test', ['checkStyle', 'jscs', 'mocha', 'karma:unit']);
-  grunt.registerTask('ci', ['checkStyle', 'jscs', 'mocha', 'karma:ci', 'karma:coverage', 'package']);
+  grunt.registerTask('ci', ['checkStyle', 'jscs', 'mocha', 'karma:ci1', 'karma:ci2', 'karma:coverage', 'package']);
   grunt.registerTask('default', ['hspserver']);
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "karma": "~0.12.0",
     "grunt-karma": "~0.8.0",
     "karma-commonjs": "0.0.6",
-    "karma-sauce-launcher": "~0.2.2",
+    "karma-sauce-launcher-shahata": "~0.2.4",
     "karma-mocha": "~0.1.1",
     "karma-expect": "~1.0.0",
     "karma-chrome-launcher": "~0.1.2",


### PR DESCRIPTION
Also fixes the Saucelabbs reporter by using `karma-sauce-launcher-shahata` which is a fork of `karma-sauce-launcher` with a fix. We should go back to `karma-sauce-launcher` once the fix fix is released, hopefully in version 0.2.5.
