### PR TITLE
Adding noder preprocessors for the compiler and the transpiler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-node_modules
+/node_modules
+/dist
+/sauce_connect.log
+/sc.log
+/test-results
+/tmp
+*.peg.js
 .DS_STORE
 ._.DS_STORE
-dist
-sauce_connect.log
-sc.log
-*.peg.js
-test-results

--- a/hsp/compiler/compile.js
+++ b/hsp/compiler/compile.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var compiler = require("./compiler");
+
+module.exports = function (code, moduleName) {
+    var compileRes = compiler.compile(code, moduleName);
+    return compileRes.code;
+};

--- a/hsp/transpiler/transpile.js
+++ b/hsp/transpiler/transpile.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var processString = require("./processString");
+
+module.exports = function (code, moduleName) {
+    var transpileRes = processString(code, moduleName);
+    return transpileRes.code;
+};

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "karma-phantomjs-launcher": "~0.1",
     "load-grunt-tasks": "~0.2.1",
     "expect.js": "0.2.0",
-    "noder-js": "~1.2.0",
+    "noder-js": "1.2.1",
     "jquery": "~1.11.0",
     "grunt-jscs-checker": "~0.4.0",
     "karma-hsp-preprocessor": "~0.0.6"


### PR DESCRIPTION
This pull request adds noder preprocessors for the compiler and the transpiler.
The (noder) compiler client-side package now includes those preprocessors, the transpiler and uglify-js.

Once integrated, this change will allow to use plunker with the following script tags:

``` html
<script type="text/javascript" src="http://noder-js.ariatemplates.com/dist/v1.2.1/noder.dev.js">{
 packaging: {
  preprocessors: [{
   pattern : /\.hsp$/,
   module: "hsp/compiler/noderPreprocessor"
  }, {
   pattern : /\.(hsp|js)$/,
   module: "hsp/transpiler/noderPreprocessor"
  }]
}</script>
<script type="text/javascript" src="http://hashspace.ariatemplates.com/dist/0.0.2-SNAPSHOT/hashspace-noder.js"></script>
<script type="text/javascript" src="http://hashspace.ariatemplates.com/dist/0.0.2-SNAPSHOT/hashspace-noder-compiler.js"></script>
<script type="noder">
   var main = require('main.hsp'); // this will load the main.hsp file, compile it and transpile it
   main().render('out');
</script>
```
