### PR TITLE
reverse key,value order in the {foreach}

### DIFF
--- a/hsp/compiler/parser/hspblocks.pegjs
+++ b/hsp/compiler/parser/hspblocks.pegjs
@@ -144,7 +144,7 @@ ForeachArgs1
   {return {item:item, key:item+"_key", colref:col}}
 
 ForeachArgs2
-  = key:VarIdentifier _ "," _ item:VarIdentifier " " _ "in " _ col:JSObjectRef 
+  = item:VarIdentifier _ "," _  key:VarIdentifier " " _ "in " _ col:JSObjectRef
   {return {item:item, key:key, colref:col}}
 
 EndForeachBlock

--- a/public/playground/layout.hsp
+++ b/public/playground/layout.hsp
@@ -38,7 +38,7 @@
 
         {if data.isSampleListVisible}
             <div class="sampleList">
-                {foreach idx,sample in data.samples}
+                {foreach sample,idx in data.samples}
                     <div class="item" onclick="{ctl.loadSample(idx)}">{idx+1}. {sample.title}</div>
                 {/foreach}
             </div>

--- a/public/samples/clock/clock.hsp
+++ b/public/samples/clock/clock.hsp
@@ -49,7 +49,7 @@ var ClockController=klass({
 		  <g transform="translate(50,50)">
 		    <circle class="clock-face" r="48"/>
 		    // minute markers 
-        	{foreach idx,m in c.minuteMarkers}
+        	{foreach m,idx in c.minuteMarkers}
         		// {foreach i in [1..60]} should be supported in a future version
           		<line class="{'major':m.major,'minor':!m.major}" y1="{m.major?35:42}" 
           		y2="45" transform="rotate({360*idx/c.minuteMarkers.length})"/>

--- a/public/samples/list1/list.hsp
+++ b/public/samples/list1/list.hsp
@@ -24,7 +24,7 @@ var ListController = klass({
         <span class="nodata">Empty list</span>
     {else}
         <ul class="">
-            {foreach idx,itm in lc.content}
+            {foreach itm,idx in lc.content}
                 {if itm.tagName==="@option"}
                     <li class="opt"><#itm/></li>
                 {else if itm.tagName==="@separator" &&  !itm_isfirst && !itm_islast}
@@ -54,7 +54,7 @@ var ListController = klass({
       <@option>{d.preferredOption} (!)</@option>
       <@separator/>
     {/if}
-    {foreach idx,itm in d.items}
+    {foreach itm,idx in d.items}
       <@option>{idx+1}. {itm}</@option>
     {/foreach}
   </#list>

--- a/public/samples/list2/list.hsp
+++ b/public/samples/list2/list.hsp
@@ -46,7 +46,7 @@ var ListCtrl = klass({
       <span class="nodata">Empty list</span>
     {else}
       <ul class="">
-        {foreach idx,itm in lc.content}
+        {foreach itm,idx in lc.content}
           {if itm.tagName==="@option"}
             <li class="opt" onclick="{lc.select(itm.value)}">
               <span class="{'item','highlight':itm.selected}"><#itm.label/></span>
@@ -75,7 +75,7 @@ var ListCtrl = klass({
       <a onclick="{empty()}">Empty</a> - 
       <a onclick="{update()}">Update list</a> 
     </@head>
-    {foreach idx,itm in d.items}
+    {foreach itm,idx in d.items}
       <@option value="K{idx}">{idx+1}. {itm}</@option>
     {/foreach}
   </#list>

--- a/public/samples/logs/logs.hsp
+++ b/public/samples/logs/logs.hsp
@@ -6,7 +6,7 @@ var log=require("hsp/rt/log");
   <a onclick="{decreaseList()}">Decrease list</a> - 
   <a onclick="{clearLogs()}">Clear logs</a>
   <ul>
-    {foreach idx,city in cities}
+    {foreach city,idx in cities}
       {log "item #"+idx+":", city}
       <li>{idx+1}. {city.name}</li>
     {/foreach}

--- a/public/test/compiler/samples/foreach2.txt
+++ b/public/test/compiler/samples/foreach2.txt
@@ -1,6 +1,6 @@
 ##### Template:
 # template test(label, passengers)
-  {foreach k,name in passengers.names}
+  {foreach name,k in passengers.names}
     {if name_isfirst}
       \<\<
     {/if}

--- a/public/test/compiler/samples/foreach3.txt
+++ b/public/test/compiler/samples/foreach3.txt
@@ -1,7 +1,7 @@
 ##### Template:
 # template test(label, passengers)
   <div>
-    {foreach k,name in passengers.names}
+    {foreach name,k in passengers.names}
       x
     {/foreach}
   </div>

--- a/public/test/rt/cptattelements3.spec.hsp
+++ b/public/test/rt/cptattelements3.spec.hsp
@@ -72,7 +72,7 @@ var ListController = klass({
 # template test4(d)
     <#list>
         <@option>1. First {d.itemName}</@option>
-        {foreach idx,itm in d.items}
+        {foreach itm,idx in d.items}
             <@option>{idx+2}. {itm}</@option>
         {/foreach}
     </#list>

--- a/public/test/rt/cptattelements4.spec.hsp
+++ b/public/test/rt/cptattelements4.spec.hsp
@@ -76,7 +76,7 @@ var ListCtrl = klass({
 
 # template test3(d)
     <#list>
-        {foreach idx,itm in d.items}
+        {foreach itm,idx in d.items}
             <@option value="{idx}">{idx+1}. {itm}</@option>
         {/foreach}
     </#list>

--- a/public/test/rt/evthandler.spec.hsp
+++ b/public/test/rt/evthandler.spec.hsp
@@ -24,7 +24,7 @@ var ht=require("hsp/utils/hashtester"),
 # /template
 
 # template test2(label,names,ctl)
-    {foreach key,name in names}
+    {foreach name,key in names}
         <span onclick="{ctl.handleClick(name,key,'literal arg',event)}">
             {:label} {key}: {:name}
         </span>

--- a/public/test/rt/foreach.spec.hsp
+++ b/public/test/rt/foreach.spec.hsp
@@ -31,7 +31,7 @@ var hsp=require("hsp/rt"),
 # /template
 
 # template test2(ds)
-    {foreach idx,person in ds.persons}
+    {foreach person,idx in ds.persons}
         Person #{idx}: {person.firstName} {person.lastName}
         {if (person_isfirst)}
             (first)

--- a/public/test/rt/log.spec.hsp
+++ b/public/test/rt/log.spec.hsp
@@ -36,7 +36,7 @@ var hsp=require("hsp/rt"),
 # /template
 
 # template test3(cities)
-    {foreach idx,city in cities}
+    {foreach city,idx in cities}
         {log idx+":", scope}
     {/foreach}
 # /template

--- a/public/test/rt/subtemplates3.spec.hsp
+++ b/public/test/rt/subtemplates3.spec.hsp
@@ -31,7 +31,7 @@ var removeItem = function (items, index) {
 
 # template list(items)
     <ul>
-        {foreach index,curItem in items}
+        {foreach curItem,index in items}
             {if true}
                 // if node is necessary to create a sub-scope
                 <#displayItem itms="{items}" idx="{index}"/>


### PR DESCRIPTION
Changes `{foreach key,value in collection}` into `{foreach value,key in collection}`. 

If we decide to change it back one day, here is a sed expression I've used to change samples / test:
`sed -r -i 's/\{foreach ([a-z]+)\,([a-z]+)/{foreach \2,\1/' [file name]`
