### PR TITLE
fix template and component attribute refresh for long paths - fix #125

### DIFF
--- a/hsp/rt/$root.js
+++ b/hsp/rt/$root.js
@@ -502,6 +502,13 @@ var $CptNode = klass({
             } else {
                 if (this.refreshAttributes) {
                     this.refreshAttributes();
+                    // for component and sub-templates the original vscope is substituted 
+                    // to the one of the component- or sub-template
+                    // so we need to revert to the parent scope to observe the correct objects
+                    var vs=this.vscope;
+                    this.vscope=this.parent.vscope;
+                    this.root.updateObjectObservers(this);
+                    this.vscope=vs;
                 }
             }
             this.adirty = false;

--- a/public/test/rt/cptattelements1.spec.hsp
+++ b/public/test/rt/cptattelements1.spec.hsp
@@ -85,6 +85,22 @@ PanelController = klass({
   </div>
 # /template
 
+var TestCtl=klass({
+      attributes:{
+        "value":{type:"string",binding:"1-way"}
+    }
+})
+
+# template item using c:TestCtl
+    Value: {c.value}
+# /template
+
+# template test7(m)
+  <div class="content">
+    <#item value="{m.prop.value}"/>
+  </div>
+# /template
+
 var HEAD=".panel .head";
 var BODY=".panel .body";
 
@@ -214,6 +230,30 @@ describe("Component attribute elements (1)", function () {
     expect(h.logs().length).to.equal(0);
     expect(h(BODY).length).to.equal(1);
     expect(h(BODY).text()).to.equal("Hashspace World!!!");
+    
+    h.$dispose();
+  });
+
+  it("validates change propagation with long expression paths", function() {
+    var h=ht.newTestContext();
+    var count=0, model={prop:{value:"hello"}};
+    
+    test7(model).render(h.container);
+    expect(h(".content").text()).to.equal("Value: hello");
+
+    // change data
+    count++;
+    h.$set(model.prop,"value","hello"+count);
+    expect(h(".content").text()).to.equal("Value: hello1");
+
+    // change path
+    h.$set(model,"prop",{value:"foo"});
+    expect(h(".content").text()).to.equal("Value: foo");
+
+    // change data
+    count++;
+    h.$set(model.prop,"value","hello"+count);
+    expect(h(".content").text()).to.equal("Value: hello2");
     
     h.$dispose();
   });

--- a/public/test/rt/subtemplates3.spec.hsp
+++ b/public/test/rt/subtemplates3.spec.hsp
@@ -41,6 +41,15 @@ var removeItem = function (items, index) {
     <a onclick="{addItem(items)}">Add item</a>
 # /template
 
+# template item(value)
+    Value: {value}
+# /template
+
+# template test1(m)
+    <div class="content">
+        <#item value="{m.prop.value}"/>
+    </div>
+# /template
 
 describe("Sub- and parent- template scope interactions", function () {
     it("validates property bubbling from sub-template to parent", function() {
@@ -63,6 +72,30 @@ describe("Sub- and parent- template scope interactions", function () {
         expect(h("li").length).to.equal(1);
         // the following assertion will fail if property changes are not properly bubbled
         expect(h("li").item(0).text()).to.equal("Remove #0");
+        
+        h.$dispose();
+    });
+
+    it("validates change propagation with long expression paths", function() {
+        var h=ht.newTestContext();
+        var count=0, model={prop:{value:"hello"}};
+        
+        test1(model).render(h.container);
+        expect(h(".content").text()).to.equal("Value: hello");
+
+        // change data
+        count++;
+        h.$set(model.prop,"value","hello"+count);
+        expect(h(".content").text()).to.equal("Value: hello1");
+
+        // change path
+        h.$set(model,"prop",{value:"foo"});
+        expect(h(".content").text()).to.equal("Value: foo");
+
+        // change data
+        count++;
+        h.$set(model.prop,"value","hello"+count);
+        expect(h(".content").text()).to.equal("Value: hello2");
         
         h.$dispose();
     });


### PR DESCRIPTION
This PR fixes issue #125.
As you can see in the fix, there were actually 2 problems:
- the observers were not recalculated (I forgot this use case!)
- and the scope has to be switched to the container scope - this is due to a specificity of sub-templates and sub-components that have to manage two scopes: the scope of the container, and the scope of the sub-template. Current implementation has only one scope object, which is assigned to the template scope and not to the container scope, thus the fix..
