### PR TITLE
add long paths support for component element insertion

### DIFF
--- a/hsp/rt/$root.js
+++ b/hsp/rt/$root.js
@@ -455,6 +455,18 @@ var $CptNode = klass({
         ni.node = ni.parent.node;
         return ni;
     },
+
+    /**
+     * Create and append the node1 and node2 boundary nodes used to delimit the component content
+     * in the parent node
+     */
+    createCommentBoundaries:function(comment) {
+        var nd=this.node;
+        this.node1 = doc.createComment("# "+comment+" "+this.pathInfo);
+        this.node2 = doc.createComment("# /"+comment+" "+this.pathInfo);
+        nd.appendChild(this.node1);
+        nd.appendChild(this.node2);
+    },
     
     /**
      * Callback called when a controller attribute or a template attribute has changed
@@ -494,6 +506,13 @@ var $CptNode = klass({
             if (this.template) {
                 var tpl=getObject(this.tplPath, this.parent.vscope);
                 tplChanged = (tpl!==this.template);
+            } else if (this.cptAttElement) {
+                // check if the cptattinsert path has changed
+                var o=getObject(this.tplPath, this.parent.vscope);
+                if (o.isCptAttElement && o!==this.cptAttElement) {
+                    // change the the cptAttElement and refresh the DOM
+                    this.createChildNodeInstances(o);
+                }
             }
 
             if (tplChanged) {

--- a/hsp/rt/cptattinsert.js
+++ b/hsp/rt/cptattinsert.js
@@ -1,3 +1,5 @@
+var doc = require("../document");
+
 /**
  * $CptAttInsert contains methods that will be added to the prototype of all
  * $CptNode node instance that correspond to an insertion of a component attribute
@@ -8,19 +10,39 @@
 module.exports.$CptAttInsert = {
   initCpt:function(cptAttElement) {
     // get the $RootNode corresponding to the templat to insert
-    var root=cptAttElement.getTemplateNode();
+    this.createPathObservers();
+    this.createCommentBoundaries("cptattinsert");
+    this.createChildNodeInstances(cptAttElement);
+  },
 
-    // append root as childNode
+  createChildNodeInstances:function(cptAttElement) {
+    if (!this.isDOMempty) {
+        this.removeChildNodeInstances(this.node1,this.node2);
+        this.isDOMempty = true;
+    }
+
+    this.cptAttElement=cptAttElement;
     this.childNodes=[];
-    this.childNodes[0]=root;
-    // instantiate sub-childNodes
-    root.render(this.node,false);
+    var root=this.cptAttElement.getTemplateNode();
+    if (root) {
+        // append root as childNode
+        this.childNodes[0]=root;
+
+        // render in a doc fragment
+        var df = doc.createDocumentFragment();
+        root.render(df,false);
+
+        this.node.insertBefore(df, this.node2);
+        root.replaceNodeBy(df, this.node); // recursively remove doc fragment reference
+        this.isDOMempty = false;
+      }
   },
 
   /**
    * Safely cut all dependencies before object is deleted
    */
   $dispose:function() {
+    this.cptAllElt=null;
     this.cleanObjectProperties();
   }
 };

--- a/hsp/rt/cptcomponent.js
+++ b/hsp/rt/cptcomponent.js
@@ -38,11 +38,7 @@ exports.$CptComponent = {
       var needCommentNodes=(this.createPathObservers() || this.ctlConstuctor.$refresh);
 
       if (needCommentNodes) {
-        var nd=this.node;
-        this.node1 = doc.createComment("# cpt "+this.pathInfo);
-        this.node2 = doc.createComment("# /cpt "+this.pathInfo);
-        nd.appendChild(this.node1);
-        nd.appendChild(this.node2);
+        this.createCommentBoundaries("cpt");
         this.createChildNodeInstances();
       } else {
         // WARNING: this changes the original vscope to the template vscope

--- a/hsp/rt/cpttemplate.js
+++ b/hsp/rt/cpttemplate.js
@@ -18,11 +18,7 @@ module.exports.$CptTemplate = {
     var isDynamicTpl=this.createPathObservers();
 
     if (isDynamicTpl) {
-      var nd=this.node;
-      this.node1 = doc.createComment("# template "+this.pathInfo);
-      this.node2 = doc.createComment("# /template "+this.pathInfo);
-      nd.appendChild(this.node1);
-      nd.appendChild(this.node2);
+      this.createCommentBoundaries("template");
       this.createChildNodeInstances();
     } else {
       arg.template.call(this, this.getTemplateArguments());

--- a/hsp/rt/cptwrapper.js
+++ b/hsp/rt/cptwrapper.js
@@ -212,6 +212,7 @@ var CptWrapper = klass({
                 if (att.type === "callback") {
                     // create an even callback function
                     this.createEventFunction(k.slice(2));
+                    cpt[k].isEmpty=(iAtt===undefined);
                     continue;
                 } else if (att.type === "template") {
                     v=null;

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -413,6 +413,25 @@ svg {
   background-color: #FF4DBE;
 }
 
+.x-tabbar > .x-tabs {
+  margin-bottom: 3px;
+}
+
+.x-tabbar .x-tab {
+  padding: 3px 5px;
+}
+
+.x-tabbar .x-tab.x-tab-selected {
+  
+  background-color: #777777;
+}
+
+.x-tabbar .x-tab-content {
+  margin:0px;
+  padding: 5px;
+  background-color: #777777;
+}
+
 // ---------------------------------------------------------------------
 // Pagination classes from bootstrap
 

--- a/public/samples/samples.js
+++ b/public/samples/samples.js
@@ -143,7 +143,7 @@ module.exports = [{
                         main : true
                     }]
         }, {
-            title : "Component with template sub-elements: List #1",
+            title : "Component with sub-elements: List #1",
             folder : "list1",
             description : "description.md",
             files : [{
@@ -151,7 +151,7 @@ module.exports = [{
                         main : true
                     }]
         }, {
-            title : "Component with component sub-elements: List #2",
+            title : "Component with sub-elements: List #2",
             folder : "list2",
             description : "description.md",
             files : [{
@@ -159,7 +159,15 @@ module.exports = [{
                         main : true
                     }]
         }, {
-            title : "Integrating 3rd party components: Chart.JS",
+            title : "Component with sub-elements: Tabbar",
+            folder : "tabbar",
+            description : "description.md",
+            files : [{
+                        src : "tabbar.hsp",
+                        main : true
+                    }]
+        }, {
+            title : "Integrating 3rd party components: Chart.js",
             folder : "thirdpartycpts",
             description : "description.md",
             files : [{

--- a/public/samples/tabbar/description.md
+++ b/public/samples/tabbar/description.md
@@ -1,0 +1,8 @@
+This example shows how a simple tab component can be implemented:
+
+[#output]
+
+A fews things can be noted here:
+
+ - the *$init()* methods of the *tab* controllers are called after the *init()* of the tabbar - as such the *selected* property of a tab may be already set before the tab is initialized.
+ - the selected tab can be referenced as a controller property - cf *selectedTab* and then directly referenced in the tabbar template: `<#ctrl.selectedTab.body/>`

--- a/public/samples/tabbar/tabbar.hsp
+++ b/public/samples/tabbar/tabbar.hsp
@@ -1,0 +1,87 @@
+var klass = require("hsp/klass");
+
+var TabCtrl = klass({
+    attributes: {
+        label: { type: "template" },
+        body: { type: "template", defaultContent: true }
+    },
+    $init:function(parent) {
+        if (!this.selected) {
+          // as parent.$init() is called before this $init()
+          // selected may be already set (to true in this case)
+          this.selected=false;
+        }
+    }
+});
+
+var TabBarCtrl = klass({
+    attributes: {
+        "class": { type: "string" },
+        "selection": { type: "int", defaultValue: 0, binding: "2-way" }
+    },
+    elements: {
+        "tab": { type: "component", controller: TabCtrl }
+    },
+    $init: function() {
+        this.select(this.selection);
+    },
+    select: function(idx) {
+        if (this.selectedTab && idx===this.selection) {
+            return;
+        }
+        // unselect previous tab
+        if (this.selection>=0 && this.selection<this.content.length) {
+            this.content[this.selection].selected=false;
+        }
+        // select new tab
+        if (idx>=0 && idx<this.content.length) {
+            this.selection=idx;
+            var tab=this.content[idx];
+            tab.selected=true;
+            this.selectedTab=tab;
+        }
+    }
+});
+
+#template tabbar using ctrl:TabBarCtrl
+  <div class="x-tabbar">
+    <nav class="x-tabs">
+        {foreach idx, tab in ctrl.content}
+            {if tab.selected}
+                <span class="x-tab x-tab-selected">
+                    <#tab.label/>
+                </span>
+            {else}
+                <a class="x-tab" onclick="{ctrl.select(idx)}">
+                    <#tab.label/>
+                </a>
+            {/if}
+            {if !tab_islast}
+              &nbsp; // separator
+            {/if}
+        {/foreach}
+    </nav>
+    <div class="x-tab-content">
+        <#ctrl.selectedTab.body />
+    </div>
+  </div>
+#/template
+
+var model={selection:0};
+# template test(m)
+  <#tabbar selection="{m.selection}">
+    <@tab label="Tab A">This content A...</@tab>
+    <@tab>
+      <@label> Tab <b>B</b> <i>!!</i>   </@label>
+      <@body>  
+        Now you see content B... <br/>
+        (on two lines)
+      </@body>
+    </@tab>
+    <@tab label="Tab C">...and now content C</@tab>
+  </#tabbar>
+  <hr/>
+  Selected tab: <span class="textvalue">{m.selection}</span>
+# /template
+
+test(model).render("output");

--- a/public/test/rt/cptattelements5.spec.hsp
+++ b/public/test/rt/cptattelements5.spec.hsp
@@ -1,0 +1,115 @@
+ 
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var klass=require("hsp/klass"),
+    $set=require("hsp/$set"),
+    ht=require("hsp/utils/hashtester");
+
+var TabCtrl = klass({
+    attributes: {
+        label: { type: "template" },
+        body: { type: "template", defaultContent: true }
+    },
+    $init:function() {
+        $set(this,"selected",false);
+    }
+});
+
+var TabBarCtrl = klass({
+    attributes: {
+        "class": { type: "string" },
+        "selection": { type: "int", defaultValue: 0, binding: "2-way" }
+    },
+    elements: {
+        "tab": { type: "component", controller: TabCtrl }
+    },
+    $init: function() {
+        this.select(this.selection);
+    },
+    select: function(idx) {
+        if (this.selectedTab && idx===this.selection) {
+            return;
+        }
+        // unselect previous selection
+        if (this.selection>=0 && this.selection<this.content.length) {
+            $set(this.content[this.selection], "selected", false);
+        }
+        // select new tab
+        if (idx>=0 && idx<this.content.length) {
+            $set(this,"selection",idx);
+            var tab=this.content[idx];
+            $set(tab,"selected",true);
+            $set(this,"selectedTab",tab);
+        }
+    }
+});
+
+#template tabbar using ctrl:TabBarCtrl
+  <div class="x-tabbar">
+    <nav class="x-tabs">
+        {foreach idx, tab in ctrl.content}
+            {if tab.selected}
+                <span class="x-tab x-tab-selected">
+                    <#tab.label/>
+                </span>
+            {else}
+                <a class="x-tab" onclick="{ctrl.select(idx)}">
+                    <#tab.label/>
+                </a>
+            {/if}
+            &nbsp;
+        {/foreach}
+    </nav>
+    <div class="x-tab-content">
+        <#ctrl.selectedTab.body />
+    </div>
+  </div>
+#/template
+
+# template test1(m)
+  <#tabbar selection="{m.selection}">
+    <@tab label="Tab A">AAA Content AAA</@tab>
+    <@tab label="Tab B">BBB Content BBB</@tab>
+    <@tab label="Tab C">CCC Content CCC</@tab>
+  </#tabbar>
+# /template
+
+var TABS=".x-tab";
+var BODY=".x-tab-content";
+
+describe("Component attribute elements (5)", function () {
+  
+    it("validates sub-element template mapping on parent component", function() {
+        var h=ht.newTestContext();
+        var model={selection:1};
+        test1(model).render(h.container);
+
+        // validate initial display
+        expect(h(BODY).text()).to.equal("BBB Content BBB");
+        expect(h(TABS).length).to.equal(3);
+        expect(h(TABS).item(1).hasClass("x-tab-selected")).to.equal(true);
+
+        // change selection
+        h(TABS).item(0).click();
+        expect(model.selection).to.equal(0);
+        expect(h(BODY).text()).to.equal("AAA Content AAA");
+
+        h.$dispose();
+    });
+
+    // TODO: support empty att template - and consider it generates an empty string..
+
+});

--- a/public/test/rt/cptwrapper.spec.hsp
+++ b/public/test/rt/cptwrapper.spec.hsp
@@ -29,7 +29,7 @@ function getNumber(s) {
     return Number(s); 
 }
 
-var lastNewMinValue=null;
+var lastNewMinValue=null, isBrCbEmpty=false;
 
 var lib={};
 // sample controller
@@ -105,6 +105,9 @@ lib.NbrField = klass({
   resetField:function() {
     var v1=this.value, v2=this.defaultvalue;
     this.onbeforereset();
+    if (this.onbeforereset.isEmpty) {
+      isBrCbEmpty=true;
+    }
     json.set(this,"internalValue",v2);
     json.set(this,"value",v2);
     this.checkValidity();
@@ -124,6 +127,11 @@ lib.nbrfield=nbrfield;
   <input type="text" value="{d.value}"/>
   <#lib.nbrfield value="{d.value}" min="-10" max="10" onbeforereset="{notifyReset(123,event)}" 
   onafterreset="{notifyReset2(event.type,event)}"/>
+# /template
+
+# template test2(d)
+  <input type="text" value="{d.value}"/>
+  <#lib.nbrfield value="{d.value}" min="-10" max="10"/>
 # /template
 
 var resetCount=0, lastResetArg=0, lastEvtType="";
@@ -302,6 +310,7 @@ it("tests a component inside another template", function() {
 
   it("tests a component event callback", function() {
     resetCount=0;
+    isBrCbEmpty=false;
     lastResetArg=0;
     lastEvtType="";
     lastEvtType2="";
@@ -315,9 +324,22 @@ it("tests a component inside another template", function() {
 
     expect(resetCount).to.equal(1); //validate that "onbeforereset" callback has been called
     expect(lastEvtType).to.equal("beforereset");
+    expect(isBrCbEmpty).to.equal(true);
     expect(lastResetArg).to.equal(123);
     expect(lastEvtType2).to.equal("afterreset");
     expect(lastEvtOldValue2).to.equal(42);
+  });
+
+  it("tests if callback is empty", function() {
+    isBrCbEmpty=false;
+    var d={value:'42'};
+    var n=test2(d);
+    var cptButton=n.node.childNodes[2];
+
+    fireEvent("click",cptButton);
+    hsp.refresh();
+
+    expect(isBrCbEmpty).to.equal(true); 
   });
 
   it("tests a component $afterRender callback", function() {

--- a/public/test/rt/index.html
+++ b/public/test/rt/index.html
@@ -60,6 +60,7 @@
 	require("test/rt/cptattelements2.spec.hsp");
 	require("test/rt/cptattelements3.spec.hsp");
 	require("test/rt/cptattelements4.spec.hsp");
+	require("test/rt/cptattelements5.spec.hsp");
 	require("test/rt/log.spec.hsp");
 	require("test/rt/let.spec.hsp");
 	require("test/rt/exprbinding.spec.hsp");


### PR DESCRIPTION
This PR fixes #124 and #33.

For #124 it adds the long paths support for component element insertions (same as for sub-templates and components).

For #33 it adds a _isEmpty_ property to the default event handler callback to let the controller know if a callback has been set..
