### PR TITLE
fix refresh for components created in dirty state

### DIFF
--- a/hsp/rt/$if.js
+++ b/hsp/rt/$if.js
@@ -125,11 +125,23 @@ var $IfNode = klass({
      * the else statement. Otherwise performs the regular recursive refresh
      */
     refresh : function () {
-        var cond = this.getConditionValue();
+        var cond = this.getConditionValue(), ch;
         if (cond !== this.lastConditionValue) {
             this.createChildNodeInstances(cond);
             this.root.updateObjectObservers(this);
+
             this.cdirty = false;
+
+            // check if one child is dirty
+            if (this.childNodes) {
+                for (var i=0;this.childNodes.length>i;i++) {
+                    ch=this.childNodes[i];
+                    if (ch.adirty || ch.cdirty) {
+                        this.cdirty=true;
+                        break;
+                    }
+                }
+            }
         }
         TNode.refresh.call(this);
     },

--- a/public/test/rt/cptinit.spec.hsp
+++ b/public/test/rt/cptinit.spec.hsp
@@ -1,0 +1,137 @@
+
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var klass=require("hsp/klass"),
+    ht=require("hsp/utils/hashtester");
+
+var TestCtrl=klass({
+  attributes:{
+    "value":{type:"string",binding:"1-way"},
+    "oninit":{type:"callback"}
+  },
+  $init:function() {
+    this.oninit();
+  }
+});
+
+# template cpt using c:TestCtrl
+    <div class="cpt">{c.value}</div>
+# /template
+
+# template test1(d)
+      {if d.show}
+          <div class="foo">
+              <#cpt value="{d.getValue()}" oninit="{d.update()}"/>
+          </div>
+      {/if}
+# /template
+
+# template test2(items)
+      {foreach itm in items}
+          <div class="foo">
+              <#cpt value="{itm.getValue()}" oninit="{itm.update()}"/>
+          </div>
+      {/foreach}
+# /template
+
+# template tpA
+  AA
+# /template
+
+# template tpB(data)
+  <div class="foo">
+      <#cpt value="{data.getValue()}" oninit="{data.update()}"/>
+  </div>
+# /template
+
+# template test3(ctxt,d)
+    <#ctxt.tpl data="{d}"/>
+# /template
+
+var Model=klass({
+  $constructor:function(v) {
+    this.show=false;
+    this.value=v;
+    this.count=0;
+  },
+  getValue:function() {
+    return this.value;
+  },
+  update:function() {
+    this.count++;
+  }
+});
+
+describe("Component init special cases", function () {
+  
+    it("validates init with callback setting the cpt dirty - {if} case", function() {
+        var h=ht.newTestContext(), d=new Model(123);
+        
+        test1(d).render(h.container);
+
+        expect(h(".foo").length).to.equal(0);
+        
+        // this creates a component in dirty state
+        h.$set(d,"show",true);
+        expect(h(".cpt").length).to.equal(1);
+        expect(h(".cpt").text()).to.equal("123");
+
+        // the following test will fail if {if} considers that its content is always clean once created
+        h.$set(d,"value",222);
+        expect(h(".cpt").text()).to.equal("222");
+
+        h.$dispose();
+    });
+
+    it("validates init with callback setting the cpt dirty - {foreach} case", function() {
+        var h=ht.newTestContext(), items=[];
+        
+        test2(items).render(h.container);
+
+        expect(h(".cpt").length).to.equal(0);
+
+        // this creates a component in dirty state
+        items.push(new Model(123));
+        h.refresh();
+        expect(h(".cpt").length).to.equal(1);
+        expect(h(".cpt").text()).to.equal("123");
+        expect(items[0].count).to.equal(1);
+
+        h.$set(items[0],"value",222);
+        expect(h(".cpt").text()).to.equal("222");
+
+        h.$dispose();
+    });
+
+    it("validates init with callback setting the cpt dirty - sub-template case", function() {
+        var h=ht.newTestContext(), ctxt={tpl:tpA}, d=new Model(123);
+        
+        test3(ctxt,d).render(h.container);
+        expect(h(".cpt").length).to.equal(0);
+
+        // this creates a component in dirty state
+        h.$set(ctxt,"tpl",tpB);
+        expect(h(".cpt").length).to.equal(1);
+        expect(h(".cpt").text()).to.equal("123");
+        expect(d.count).to.equal(1);
+
+        h.$set(d,"value",222);
+        expect(h(".cpt").text()).to.equal("222");
+
+        h.$dispose();
+    });
+
+});

--- a/public/test/rt/index.html
+++ b/public/test/rt/index.html
@@ -47,6 +47,7 @@
 	require("test/rt/cptattelements3.spec.hsp");
 	require("test/rt/cptattelements4.spec.hsp");
 	require("test/rt/cptattelements5.spec.hsp");
+	require("test/rt/cptinit.spec.hsp");
 	require("test/rt/cptbinding.spec.hsp");
 	require("test/rt/cptintegration.spec.hsp");
 	require("test/rt/cptwrapper.spec.hsp");


### PR DESCRIPTION
This PR fixes a refresh issue that @divdavem found in one of his applications.

The problem occurs when an {if} statement changes its content, and when the new content contains a component that is created in dirty state. As {if} assumed content was always created in a clean state, it used  to set itself to `cdirty=false` - which broke the refresh chain, and made subsequent refresh impossible.

Now you may wonder how to create a component in dirty state? Actually since the new observation rules associated to function containing expressions it is possible to create a component and set it dirty right after its $init(). For this you need to call a callback in the init, and change an object that is indirectly observed by the component (e.g. a function context - cf. new tests in the PR)
