### PR TITLE
update TNode dispose  - fix #135

### DIFF
--- a/hsp/rt/tnode.js
+++ b/hsp/rt/tnode.js
@@ -63,13 +63,16 @@ var TNode = klass({
         if (this.root) {
             this.root.rmAllObjectObservers(this);
         }
+        // Note: we must not set this.children to null here.
+        // Indeed children are usually static (on the constructor) and so children=null should have no
+        // effect, except for $CptAttElement where it may be set at at instance level for cpt attributes
+        // created by the run-time
         this.obsPairs = null;
         this.htmlCbs = null;
         this.node = null;
         this.parent = null;
         this.root = null;
         this.vscope = null;
-        this.children = null;
         this.atts = null;
         this.evtHandlers = null;
     },

--- a/public/samples/tabbar/tabbar.hsp
+++ b/public/samples/tabbar/tabbar.hsp
@@ -67,21 +67,27 @@ var TabBarCtrl = klass({
   </div>
 #/template
 
-var model={selection:0};
-# template test(m)
-  <#tabbar selection="{m.selection}">
-    <@tab label="Tab A">This content A...</@tab>
-    <@tab>
-      <@label> Tab <b>B</b> <i>!!</i>   </@label>
-      <@body>  
-        Now you see content B... <br/>
-        (on two lines)
-      </@body>
+# template test
+  {let showSubTabs=false, selection1=0, selection2=0}
+  <#tabbar selection="{selection1}">
+    <@tab label="Tab A">
+      {if showSubTabs}
+        <#tabbar selection="{selection2}">
+            <@tab label="Tab 1">Sub tab 1</@tab>
+            <@tab label="Tab 2">Sub tab 2</@tab>
+        </#tabbar>
+      {else}
+        Tab A content...
+      {/if}
     </@tab>
-    <@tab label="Tab C">...and now content C</@tab>
+    <@tab label="Tab B">Tab B content...</@tab>
+    <@tab label="Tab C">Tab C content...</@tab>
   </#tabbar>
-  <hr/>
-  Selected tab: <span class="textvalue">{m.selection}</span>
+  <label for="cb1">
+    <input id="cb1" type="checkbox" model="{showSubTabs}"/>
+    Show nested tabs in tab A
+  </label>
 # /template
 
-test(model).render("output");
+
+test().render("output");

--- a/public/test/rt/cptattelements5.spec.hsp
+++ b/public/test/rt/cptattelements5.spec.hsp
@@ -87,6 +87,19 @@ var TabBarCtrl = klass({
   </#tabbar>
 # /template
 
+# template test2(m)
+  <#tabbar selection="{m.selection1}">
+    <@tab label="Tab A">
+        <#tabbar selection="{m.selection2}">
+            <@tab label="tab1">Sub tab 1</@tab>
+            <@tab label="tab2">Sub tab 2</@tab>
+        </#tabbar>
+    </@tab>
+    <@tab label="Tab B">BBB Content BBB</@tab>
+    <@tab label="Tab C">CCC Content CCC</@tab>
+  </#tabbar>
+# /template
+
 var TABS=".x-tab";
 var BODY=".x-tab-content";
 
@@ -106,6 +119,48 @@ describe("Component attribute elements (5)", function () {
         h(TABS).item(0).click();
         expect(model.selection).to.equal(0);
         expect(h(BODY).text()).to.equal("AAA Content AAA");
+
+        h.$dispose();
+    });
+
+    it("validates nested component with template sub-elements", function() {
+        var h=ht.newTestContext();
+        var model={selection1:0,selection2:1};
+        test2(model).render(h.container);
+
+        // validate initial display
+        expect(h(BODY).length).to.equal(2);
+        expect(h(BODY).item(1).text()).to.equal("Sub tab 2");
+        expect(h(TABS).length).to.equal(5);
+        expect(h(TABS).item(0).hasClass("x-tab-selected")).to.equal(true);
+        expect(h(TABS).item(4).hasClass("x-tab-selected")).to.equal(true);
+
+        // change main-tab selection
+        h(TABS).item(1).click();
+        expect(h(BODY).length).to.equal(1);
+        expect(h(TABS).length).to.equal(3);
+        expect(h(BODY).text()).to.equal("BBB Content BBB");
+
+        // set back
+        h(TABS).item(0).click();
+        expect(h(BODY).length).to.equal(2);
+        expect(h(TABS).length).to.equal(5);
+        expect(h(BODY).item(1).text()).to.equal("Sub tab 2");
+
+        // change sub-tab
+        h(TABS).item(3).click();
+        expect(h(BODY).item(1).text()).to.equal("Sub tab 1");
+
+        // change main again
+        h(TABS).item(2).click();
+        expect(h(BODY).length).to.equal(1);
+        expect(h(TABS).length).to.equal(3);
+        expect(h(BODY).text()).to.equal("CCC Content CCC");
+
+        // set back
+        h(TABS).item(0).click();
+        expect(h(BODY).length).to.equal(2);
+        expect(h(BODY).item(1).text()).to.equal("Sub tab 1");
 
         h.$dispose();
     });


### PR DESCRIPTION
Fix for issue #135.

This issue was due to a specificity of the $CptAttElement that can be created by the runtime for default attribute elements (i.e. those with defaultContent=true). In this case the children collection is not stored at prototype level and must not be deleted, otherwise the component cannot be displayed multiple times (e.g. show/hide use cases)
