### PR TITLE
support full expressions in foreach collections - fix issue #131

### DIFF
--- a/hsp/compiler/parser/hspblocks.pegjs
+++ b/hsp/compiler/parser/hspblocks.pegjs
@@ -136,11 +136,11 @@ ForeachArgs
   = ForeachArgs1 / ForeachArgs2
 
 ForeachArgs1
-  = item:VarIdentifier " " _ "in " _ col:JSObjectRef 
+  = item:VarIdentifier " " _ "in " _ col:HExpressionContent 
   {return {item:item, key:item+"_key", colref:col}}
 
 ForeachArgs2
-  = key:VarIdentifier _ "," _ item:VarIdentifier " " _ "in " _ col:JSObjectRef 
+  = key:VarIdentifier _ "," _ item:VarIdentifier " " _ "in " _ col:HExpressionContent 
   {return {item:item, key:key, colref:col}}
 
 EndForeachBlock

--- a/hsp/compiler/treebuilder/syntaxTree.js
+++ b/hsp/compiler/treebuilder/syntaxTree.js
@@ -514,8 +514,13 @@ var SyntaxTree = klass({
         var node = new Node("foreach"), block = blocks[index];
         node.item = block.item;
         node.key = block.key;
-        node.collection = block.colref;
+        //node.collection = block.colref;
+        //node.collection.bound = true;
+
+        var expr = new HExpression(block.colref, this);
+        node.collection = expr.getSyntaxTree();
         node.collection.bound = true;
+
         node.content = [];
         out.push(node);
 

--- a/hsp/rt/$foreach.js
+++ b/hsp/rt/$foreach.js
@@ -53,9 +53,8 @@ var $ForEachNode = klass({
         this.forType = 0; // 0=in / 1=of / 2=on
         this.colExpIdx = colExpIdx;
 
-        // force binding for the collection
-        exps["e" + colExpIdx][0] = 1;
         TNode.$constructor.call(this, exps);
+        this.isBound=(this.eh.getExpr(colExpIdx).bound===true);
         this.displayedCol = null; // displayed collection
 
         this.itemNode = new $ItemNode(children, itemName, itemKeyName); // will be used as generator for each childNode
@@ -94,7 +93,9 @@ var $ForEachNode = klass({
         var cn, forType = this.forType, itemNode = this.itemNode;
         if (col) {
             // create an observer on the collection to be notified of the changes (cf. refresh)
-            this.root.createObjectObserver(this, col);
+            if (this.isBound) {
+                this.root.createObjectObserver(this, col);
+            }
             this.displayedCol = col;
 
             this.childNodes = cn = [];

--- a/public/test/compiler/samples/foreach1.txt
+++ b/public/test/compiler/samples/foreach1.txt
@@ -13,7 +13,17 @@
     "args": ["things"],
     "content": [
       {"type": "text","value": "Foreach test: "},
-      {"type": "foreach","item":"thing","key":"thing_key",colref:{"category":"objectref","path": ["things"]}},
+      {"type": "foreach","item":"thing","key":"thing_key",
+        "colref": {
+          "type": "Variable",
+          "name": "things",
+          "code": "things",
+          "category": "jsexpression",
+          "expType": "Variable",
+          "line": 3,
+          "column": 22
+        }
+      },
       {"type": "text","value": " - "},
       {"type": "expression", expType:"Variable", "category": "jsexpression", name:"thing"},
       {"type": "text","value": " - "},
@@ -31,13 +41,23 @@
     "args": ["things"],
     "content": [
       {"type": "text","value": "Foreach test: "},
-      {"type": "foreach","item":"thing","key":"thing_key",collection:{"category":"objectref","path": ["things"]}, content:[
-        {"type": "textblock", "content": [
-          {"type": "text","value": " - "},
-          {"type": "expression", "category": "objectref", "bound": true, "path": [ "thing" ]}, 
-          {"type": "text","value": " - "}
-        ]}
-      ]}
+        {"type": "foreach","item":"thing","key":"thing_key",
+        "collection": {
+            "type": "expression",
+            "category": "objectref",
+            "bound": true,
+            "path": [ "things" ],
+            "line": 3,
+            "column": 22
+        },
+        content:[
+          {"type": "textblock", "content": [
+            {"type": "text","value": " - "},
+            {"type": "expression", "category": "objectref", "bound": true, "path": [ "thing" ]}, 
+            {"type": "text","value": " - "}
+          ]}
+        ]
+      }
     ]
   }
 ]

--- a/public/test/compiler/samples/foreach2.txt
+++ b/public/test/compiler/samples/foreach2.txt
@@ -19,7 +19,18 @@
     "name": "test",
     "args": ["label","passengers"],
     "content": [
-      {"type": "foreach","item":"name","key":"k",colref:{"category":"objectref","path": ["passengers","names"]}},
+      {"type": "foreach","item":"name","key":"k",
+        "colref": {
+          "type": "PropertyAccess",
+          "base": { "type": "Variable", "name": "passengers", "code": "passengers"},
+          "name": "names",
+          "code": "passengers.names",
+          "category": "jsexpression",
+          "expType": "PropertyAccess",
+          "line": 2,
+          "column": 22
+        }
+      },
       {"type": "if", "condition": {type: "Variable", "category": "jsexpression", "name": "name_isfirst"}},
       {"type": "text","value": "<< "},
       {"type": "endif"},
@@ -45,29 +56,39 @@
     "name": "test",
     "args": ["label","passengers"],
     "content": [
-      {"type": "foreach","item":"name","key":"k",collection:{"category":"objectref","path": ["passengers","names"]},content:[
-        {"type": "if",
-          "condition": {"category": "objectref", "path": ["name_isfirst"]},
-          "content1": [
-            {"type": "text", "value": "<< "}
-          ]
+      {"type": "foreach","item":"name","key":"k",
+        "collection": {
+          "type": "expression",
+          "category": "objectref",
+          "bound": true,
+          "path": [ "passengers", "names" ],
+          "line": 2,
+          "column": 22
         },
-        {"type": "textblock", "content": [
-          {"type": "expression", "category": "objectref", "bound": false, "path": [ "label" ]},
-          {"type": "text", "value": " "},
-          {"type": "expression", "category": "objectref", "bound": true, "path": [ "k" ]},
-          {"type": "text", "value": ": "},
-          {"type": "expression", "category": "objectref", "bound": true, "path": [ "name" ]},
-          {"type": "text", "value": " "}
-        ]},
-        {"type": "if",
-          "condition": {"category": "objectref", "path": ["name_islast"]},
-          "content1": [
-            {"type": "text", "value": ">> "}
-          ]
-        }
-      ]
-    }]
+        content:[
+          {"type": "if",
+            "condition": {"category": "objectref", "path": ["name_isfirst"]},
+            "content1": [
+              {"type": "text", "value": "<< "}
+            ]
+          },
+          {"type": "textblock", "content": [
+            {"type": "expression", "category": "objectref", "bound": false, "path": [ "label" ]},
+            {"type": "text", "value": " "},
+            {"type": "expression", "category": "objectref", "bound": true, "path": [ "k" ]},
+            {"type": "text", "value": ": "},
+            {"type": "expression", "category": "objectref", "bound": true, "path": [ "name" ]},
+            {"type": "text", "value": " "}
+          ]},
+          {"type": "if",
+            "condition": {"category": "objectref", "path": ["name_islast"]},
+            "content1": [
+              {"type": "text", "value": ">> "}
+            ]
+          }
+        ]
+      }
+    ]
   }
 ]
 

--- a/public/test/compiler/samples/foreach3.txt
+++ b/public/test/compiler/samples/foreach3.txt
@@ -8,6 +8,7 @@
 # /template
 
 ##### Parsed Tree
+
 [
   {
     "type": "template",
@@ -16,7 +17,18 @@
     "closed": true,
     "content": [
       {"type": "element","name": "div","closed": false,"attributes": []},
-      {"type": "foreach","item":"name","key":"k",colref:{"category":"objectref","path": ["passengers","names"]}},
+      {"type": "foreach","item":"name","key":"k",
+        "colref": {
+          "type": "PropertyAccess",
+          "base": { "type": "Variable", "name": "passengers", "code": "passengers" },
+          "name": "names",
+          "code": "passengers.names",
+          "category": "jsexpression",
+          "expType": "PropertyAccess",
+          "line": 3,
+          "column": 24
+        }
+      },
       {"type": "text","value": "x "},
       {"type": "endforeach"},
       {"type": "text","value": " "},
@@ -26,6 +38,7 @@
 ]
 
 ##### Syntax Tree
+
 [
   {
     "type": "template",
@@ -34,7 +47,14 @@
     "content": [
       {"type": "element","name": "div","closed": false,"attributes": [],"content": [
           {"type": "foreach","item": "name","key": "k", 
-            "collection": {"category": "objectref","path": ["passengers","names"],"code": "passengers.names", "bound": true},
+            "collection": {
+              "type": "expression",
+              "category": "objectref",
+              "bound": true,
+              "path": [ "passengers", "names" ],
+              "line": 3,
+              "column": 24
+            },
             "content": [
               {"type": "text","value": "x "}
             ]

--- a/public/test/compiler/samples/foreach4.txt
+++ b/public/test/compiler/samples/foreach4.txt
@@ -1,0 +1,28 @@
+##### Template:
+# template test
+  {foreach itm in items}
+    {itm}
+  {/foreach}
+# /template
+
+##### Parsed Tree
+
+"skip"
+
+##### Syntax Tree
+
+"skip"
+
+##### Template Code
+test=[
+  n.$foreach (
+    {e1:[2,1,_items]},
+    "itm_key",
+    "itm",
+    0,
+    1,
+    [
+      n.$text({e1:[1,1,"itm"]}, ["",1," "])
+    ]
+  )
+]

--- a/public/test/compiler/tests.js
+++ b/public/test/compiler/tests.js
@@ -89,7 +89,7 @@ describe('Block Parser: ', function () {
     };
 
     var samples = ut.getSampleNames(__dirname + "/samples");
-    //samples=["jsexpression12"];
+    //samples=["foreach4"];
 
     for (var i = 0, sz = samples.length; sz > i; i++) {
         // create one test for each sample

--- a/public/test/rt/foreach.spec.hsp
+++ b/public/test/rt/foreach.spec.hsp
@@ -80,6 +80,18 @@ var hsp=require("hsp/rt"),
     {/foreach}
 # /template
 
+var items=[
+    {value:"Iteam A"},
+    {value:"Item B"}
+];
+# template test7
+    {foreach item in items}
+        <div class="itm">
+            {item.value}
+        </div>
+    {/foreach}
+# /template
+
 describe("ForEach Node", function () {
     function test1Count (arrayLength) {
         // return number of items produced by test 1
@@ -551,6 +563,21 @@ describe("ForEach Node", function () {
         expect(inputNodes.length).to.equal(0);
         expect(spanNodes.length).to.equal(1);
         expect(spanNodes.item(0).text()).to.equal("AA");
+
+        h.$dispose();
+    });
+
+    it("validates display with global collection", function() {
+        var h=ht.newTestContext();
+        test7().render(h.container);
+
+        expect(h(".itm").length).to.equal(2);
+
+        items.push({value:"Item C"});
+        h.refresh();
+
+        // no binding - so nbr of items should be the same
+        expect(h(".itm").length).to.equal(2);
 
         h.$dispose();
     });


### PR DESCRIPTION
All is in the title: this PR changes the {foreach} statement grammar to support the same type of expressions as for text or attributes elements. It also fixes issue #131: now global collections can be directly displayed through {foreach} statements.
