### PR TITLE
fix invalid propagation of node change in cpttemplate - fix issue #143

### DIFF
--- a/hsp/rt/cpttemplate.js
+++ b/hsp/rt/cpttemplate.js
@@ -49,9 +49,9 @@ module.exports.$CptTemplate = {
         this.node = df;
         this.template.call(this, args);
 
-        this.node = realNode;
-        this.node.insertBefore(df, this.node2);
+        realNode.insertBefore(df, this.node2);
         this.replaceNodeBy(df , realNode); // recursively remove doc fragment reference
+        // now this.node=realNode
         this.isDOMempty = false;
       }
   },

--- a/public/test/rt/subtemplates3.spec.hsp
+++ b/public/test/rt/subtemplates3.spec.hsp
@@ -51,6 +51,21 @@ var removeItem = function (items, index) {
     </div>
 # /template
 
+# template innerTemplate(data)
+    {if data.checked}[x]{else}[ ]{/if} Checked
+# /template
+
+# template intermediateTemplate(data)
+  <#innerTemplate data="{data}"/>
+# /template 
+
+# template test2(data)
+  <div class="content">
+    <#data.template data="{data}"/>
+  </div>
+# /template
+
+
 describe("Sub- and parent- template scope interactions", function () {
     it("validates property bubbling from sub-template to parent", function() {
         var h=ht.newTestContext();
@@ -97,6 +112,20 @@ describe("Sub- and parent- template scope interactions", function () {
         h.$set(model.prop,"value","hello"+count);
         expect(h(".content").text()).to.equal("Value: hello2");
         
+        h.$dispose();
+    });
+
+    it("validates root node change propagation after render", function() {
+        var h=ht.newTestContext(), model={template:intermediateTemplate, checked: true};
+
+        var r=test2(model);
+        r.render(h.container);
+        expect(h(".content").text()).to.equal("[x] Checked");
+
+        // uncheck
+        h.$set(model,"checked",false);
+        expect(h(".content").text()).to.equal("[ ] Checked");
+
         h.$dispose();
     });
 });


### PR DESCRIPTION
Fix for issue #143
The problem lied in a wrong propagation of the doc-fragment node change. This propagation is necessary as when a doc-fragment is appended to another DOM element, it becomes empty (and as such useless) - and this happens any time a new piece is generated off-DOM and then inserted back into another DOM elt. The problem is that each node in hashspace needs to keep a reference to the final DOM - so the previous reference to the doc fragment have to be recursively replaced by the new DOM element (that can be also a doc fragment btw.!)

Well.. not sure I was super clear - but feel free to come and see me if you want to know more about this..
