### PR TITLE
refactor: use relative paths in requires

### DIFF
--- a/hsp/utils/eventgenerator.js
+++ b/hsp/utils/eventgenerator.js
@@ -18,8 +18,8 @@
  * Taken from Aria Templates: https://github.com/ariatemplates/ariatemplates/blob/master/src/aria/utils/FireDomEvent.js
  */
 
-var typeUtils = require("hsp/utils/type"),
-    log = require("hsp/rt/log");
+var typeUtils = require("./type"),
+    log = require("../rt/log");
 
 var // mouse events supported
 events = {

--- a/hsp/utils/hashtester.js
+++ b/hsp/utils/hashtester.js
@@ -1,10 +1,10 @@
-var klass = require("hsp/klass"),
-    doc=require("hsp/document"),
-    hsp=require("hsp/rt"),
-    fireEvent=require("hsp/utils/eventgenerator").fireEvent,
+var klass = require("../klass"),
+    doc=require("../document"),
+    hsp=require("../rt"),
+    fireEvent=require("./eventgenerator").fireEvent,
     $=require("node_modules/jquery/dist/jquery.min.js"),
-    log=require("hsp/rt/log"),
-    $set=require("hsp/$set");
+    log=require("../rt/log"),
+    $set=require("../$set");
 
 var HtException=klass({
     $constructor:function(code,text) {


### PR DESCRIPTION
This is the first part of fixes that should allow us, in the end, to solve https://github.com/ariatemplates/hashspace/issues/121.

Problem description: in node.js the `require('foo')` will try to load a module from a "defined root folder" that defaults to `node_modules`. As of today the node's loading algorithm assumes that there is only one predefined "root folder". Contrary to the node's loading algorithm, in our code base we assume that there are multiple ones:
- `.` when we reference hsp: `require("hsp/foo/bar.js")`
- `node_modules` when we reference "real" 3rd party modules (accorn etc.).

This PR is the first one that is aiming to have only one "root folder" being `node_modules`. To achieve this we need to stop using `require("hsp/foo/bar.js")` and use relative paths for internal #space files instead.
