### PR TITLE
add support of pipe and new operators - implements #123

### DIFF
--- a/hsp/rt/$foreach.js
+++ b/hsp/rt/$foreach.js
@@ -53,8 +53,7 @@ var $ForEachNode = klass({
         this.forType = 0; // 0=in / 1=of / 2=on
         this.colExpIdx = colExpIdx;
 
-        TNode.$constructor.call(this, exps);
-        this.isBound=(this.eh.getExpr(colExpIdx).bound===true);
+        TNode.$constructor.call(this, exps, true);
         this.displayedCol = null; // displayed collection
 
         this.itemNode = new $ItemNode(children, itemName, itemKeyName); // will be used as generator for each childNode
@@ -93,9 +92,6 @@ var $ForEachNode = klass({
         var cn, forType = this.forType, itemNode = this.itemNode;
         if (col) {
             // create an observer on the collection to be notified of the changes (cf. refresh)
-            if (this.isBound) {
-                this.root.createObjectObserver(this, col);
-            }
             this.displayedCol = col;
 
             this.childNodes = cn = [];

--- a/hsp/rt/tnode.js
+++ b/hsp/rt/tnode.js
@@ -38,11 +38,11 @@ var TNode = klass({
     obsPairs : null,      // Array of observed [obj, property] pairs associated to this object
     needSubScope : false, // true if a dedicated sub-scope should be created for this node
 
-    $constructor : function (exps) {
+    $constructor : function (exps,observeExpTarget) {
         this.isStatic = (exps === 0);
         if (!this.isStatic) {
             // create ExpHandler
-            this.eh = new ExpHandler(exps);
+            this.eh = new ExpHandler(exps,observeExpTarget);
         }
     },
 

--- a/public/samples/modifiers/description.md
+++ b/public/samples/modifiers/description.md
@@ -1,0 +1,13 @@
+This example shows how modifiers can be used to adapt the value of an expression to the desired display. Modifiers are functions that take as first argument the value of the expression to be adapted and that return the new value. They can also take other arguments that should be separated with colons - e.g. ```{some.expression|modifier1:arg2:arg3|modifier2}```
+
+[#output]
+
+Hashspace acually supports two types of modifiers:
+
+ - either **simple functions** that take the value to be modified as first argument and return the new value. Those values could be of any JavaScript type, e.g. Strings or Arrays *- cf. changeCase function in the code sample*
+ - or **JavaScript objects** that expose transformation functions. As objects can hold state, this provides a simple way to change and expose internal modifier properties without overloading the main controller with this logic *- cf. Sorter example in the code sample*.
+
+Notes:
+
+  - Modifiers must always return a copy of the values passed as argument. Otherwise modifiers will create side effects on other expressions bound to the same data.
+  - As hashspace use the pipe sign for modifiers, the JavaScript bitwise operator (also using the pipe sign) is not supported in hashspace expressions.

--- a/public/samples/modifiers/modifiers.hsp
+++ b/public/samples/modifiers/modifiers.hsp
@@ -1,0 +1,74 @@
+var klass=require("hsp/klass");
+
+function changeCase(s,arg) {
+    if (arg==="upper") {
+        return (""+s).toUpperCase();
+    } else if (arg==="lower") {
+        return (""+s).toLowerCase();
+    } 
+    return s;
+}
+
+var Sorter=klass({
+    $constructor:function(property) {
+        this.ascending=true;
+        this.pp=property;
+    },
+    sort:function(array) {
+        // copy array
+        var arr=[], pp=this.pp, ascending=this.ascending;
+        for (var i=0,sz=array.length;sz>i;i++) {
+            arr[i]=array[i];
+        }
+        // sort
+        arr.sort(function (a,b) {
+            if (a[pp]>b[pp]) {
+                return ascending? 1 : -1;
+            } else if (a[pp]==b[pp]) {
+                return 0;
+            } else {
+                return ascending? -1 : 1;
+            }
+        });
+        return arr;
+    },
+    toggleOrder:function() {
+        this.ascending=!this.ascending;
+    }
+})
+
+# template sample(d)
+    <div class="section2">
+        Message in capital letters:
+        <span class="textvalue">{d.msg|changeCase:"upper"}</span><br/>
+        Message in lower case:
+        <span class="textvalue">{d.msg|changeCase:"lower"}</span>
+    </div>
+    <div class="section2">
+        {let fnSorter=new Sorter("firstName")}
+        Sorted list:
+        <ol>
+            {foreach p in d.persons|fnSorter.sort}
+                <li>
+                    {p.firstName} {p.lastName}
+                </li>
+            {/foreach}
+        </ol>
+        <a onclick="{fnSorter.toggleOrder()}">
+            Toggle sort order (current: {fnSorter.ascending? "ascending" : "descending"})
+        </a>
+    </div>
+# /template
+
+var data={
+    msg:"Hello Simpsons!",
+    persons:[
+        {firstName:"Homer",lastName:"Simpsons"},
+        {firstName:"Marge",lastName:"Simpsons"},
+        {firstName:"Bart"},
+        {firstName:"Lisa"},
+        {firstName:"Maggy"}
+    ]
+};
+
+sample(data).render("output");

--- a/public/samples/samples.js
+++ b/public/samples/samples.js
@@ -55,19 +55,27 @@ module.exports = [{
                         main : true
                     }]
         }, {
-            title : "Traces, logs and debugging",
-            folder : "logs",
-            description : "description.md",
-            files : [{
-                        src : "logs.hsp",
-                        main : true
-                    }]
-        }, {
             title : "Local variables with {let}",
             folder : "let",
             description : "description.md",
             files : [{
                         src : "let.hsp",
+                        main : true
+                    }]
+        }, {
+            title : "Modifiers: piped expressions",
+            folder : "modifiers",
+            description : "description.md",
+            files : [{
+                        src : "modifiers.hsp",
+                        main : true
+                    }]
+        }, {
+            title : "Traces, logs and debugging",
+            folder : "logs",
+            description : "description.md",
+            files : [{
+                        src : "logs.hsp",
                         main : true
                     }]
         }, {

--- a/public/test/compiler/errsamples/if1.txt
+++ b/public/test/compiler/errsamples/if1.txt
@@ -6,9 +6,16 @@
 # /template
 
 ##### Error:
-[ { 
-    description: 'Invalid if condition',
-    line: 2,
-    column: 9,
-    code: '(person.isAdult' 
-} ]
+[
+  {
+    "description": "Invalid expression",
+    "line": 2,
+    "column": 5,
+    "code": "if (person.isAdult"
+  },
+  {
+    "description": "{/if} statement does not match any {if} block",
+    "line": 4,
+    "column": 5
+  }
+]

--- a/public/test/compiler/errsamples/jsexpression3.txt
+++ b/public/test/compiler/errsamples/jsexpression3.txt
@@ -1,0 +1,14 @@
+##### Template:
+# template test(person)
+  {person.name|foo:}
+# /template
+
+##### Error:
+[
+  {
+    "description": "Invalid expression",
+    "line": 2,
+    "column": 3,
+    "code": "person.name:"
+  }
+]

--- a/public/test/compiler/errsamples/jsexpression4.txt
+++ b/public/test/compiler/errsamples/jsexpression4.txt
@@ -1,0 +1,14 @@
+##### Template:
+# template test(person)
+  {person.name|}
+# /template
+
+##### Error:
+[
+  {
+    "description": "Invalid expression",
+    "line": 2,
+    "column": 3,
+    "code": "person.name|"
+  }
+]

--- a/public/test/compiler/samples/jsexpression13.txt
+++ b/public/test/compiler/samples/jsexpression13.txt
@@ -1,0 +1,95 @@
+##### Template:
+# template test(person)
+	{orderBy(person.list,"firstName")}
+# /template
+
+##### Parsed Tree:
+[
+  {
+    "type": "template","name": "test","args": ["person"],"line": 1,"column": 1,
+    "content": [
+      {
+        "type": "expression",
+        "name": {
+          "type": "Variable",
+          "name": "orderBy",
+          "code": "orderBy"
+        },
+        "arguments": [
+          {
+            "type": "PropertyAccess",
+            "base": {
+              "type": "Variable",
+              "name": "person",
+              "code": "person"
+            },
+            "name": "list",
+            "code": "person.list"
+          },
+          {
+            "type": "expression",
+            "category": "string",
+            "value": "firstName",
+            "code": "firstName"
+          }
+        ],
+        "category": "jsexpression",
+        "expType": "FunctionCall",
+        "line": 2,
+        "column": 2,
+        "bound": true
+      }
+    ],
+    "closed": true,
+    "endLine": 3
+  }
+]
+
+
+##### Syntax Tree:
+[
+  {
+    "type": "template","name": "test","args": ["person"],"export": false,"startLine": 1,"endLine": 3,
+    "content": [
+      {
+        "type": "textblock",
+        "content": [
+          {
+            "type": "expression",
+            "category": "functionref",
+            "bound": true,
+            "path": [
+              "_orderBy"
+            ],
+            "args": [
+              {
+                "type": "expression",
+                "category": "objectref",
+                "path": [
+                  "person",
+                  "list"
+                ]
+              },
+              {
+                "type": "expression",
+                "category": "string",
+                "value": "firstName",
+                "code": "firstName"
+              }
+            ],
+            "line": 2,
+            "column": 2
+          }
+        ]
+      }
+    ]
+  }
+]
+
+##### Template Code
+test=[
+  n.$text({
+    e1:[4,1,_orderBy,1,2,0,"firstName"],
+    e2:[1,2,"person","list"]
+  },["",1])
+]

--- a/public/test/compiler/samples/jsexpression14.txt
+++ b/public/test/compiler/samples/jsexpression14.txt
@@ -1,0 +1,91 @@
+##### Template:
+# template test(person)
+  {person.list|orderBy:"firstName"}
+# /template
+
+##### Parsed Tree:
+[
+  {
+    "type": "template","name": "test","args": ["person"],"line": 1,"column": 1,
+    "content": [
+      {
+        "type": "expression",
+        "base": { "type": "Variable", "name": "person", "code": "person" },
+        "name": "list",
+        "code": "person.list",
+        "category": "jsexpression",
+        "expType": "PropertyAccess",
+        "line": 2,
+        "column": 3,
+        "pipes": [
+          {
+            "fnexpr": {
+              "type": "Variable",
+              "name": "orderBy",
+              "code": "orderBy"
+            },
+            "args": [
+              {
+                "type": "expression",
+                "category": "string",
+                "value": "firstName",
+                "code": "firstName"
+              }
+            ]
+          }
+        ],
+        "bound": true
+      }
+    ],
+    "closed": true,
+    "endLine": 3
+  }
+]
+
+##### Syntax Tree:
+[
+  {
+    "type": "template","name": "test","args": ["person"],"export": false,"startLine": 1,"endLine": 3,
+    "content": [
+      {
+        "type": "textblock",
+        "content": [
+          {
+            "type": "expression",
+            "category": "functionref",
+            "bound": true,
+            "path": [
+              "_orderBy"
+            ],
+            "args": [
+              {
+                "type": "expression",
+                "category": "objectref",
+                "path": [
+                  "person",
+                  "list"
+                ]
+              },
+              {
+                "type": "expression",
+                "category": "string",
+                "value": "firstName",
+                "code": "firstName"
+              }
+            ],
+            "line": 2,
+            "column": 3
+          }
+        ]
+      }
+    ]
+  }
+]
+
+##### Template Code
+test=[
+  n.$text({
+    e1:[4,1,_orderBy,1,2,0,"firstName"],
+    e2:[1,2,"person","list"]
+  },["",1])
+]

--- a/public/test/compiler/samples/jsexpression15.txt
+++ b/public/test/compiler/samples/jsexpression15.txt
@@ -1,0 +1,158 @@
+##### Template:
+# template test(person)
+  <div title="{foo(bar(person.name+"!",1+2))}">
+    hello
+  </div>
+# /template
+
+##### Parsed Tree:
+[
+  {
+    "type": "template","name": "test","args": ["person"],"line": 1,"column": 1,
+    "content": [
+      {
+        "type": "element",
+        "name": "div",
+        "closed": false,
+        "attributes": [
+          {
+            "type": "attribute",
+            "name": "title",
+            "value": [
+              {
+                "type": "expression",
+                "name": {
+                  "type": "Variable",
+                  "name": "foo",
+                  "code": "foo"
+                },
+                "arguments": [
+                  {
+                    "type": "FunctionCall",
+                    "name": {"type": "Variable","name": "bar","code": "bar"},
+                    "arguments": [
+                      {
+                        "type": "BinaryExpression",
+                        "operator": "+",
+                        "left": {
+                          "type": "PropertyAccess",
+                          "base": {"type": "Variable", "name": "person", "code": "person"},
+                          "name": "name",
+                          "code": "person.name"
+                        },
+                        "right": {
+                          "type": "expression",
+                          "category": "string",
+                          "value": "!",
+                          "code": "!"
+                        }
+                      },
+                      {
+                        "type": "BinaryExpression",
+                        "operator": "+",
+                        "left": {
+                          "type": "expression",
+                          "category": "number",
+                          "value": 1,
+                          "code": "1"
+                        },
+                        "right": {
+                          "type": "expression",
+                          "category": "number",
+                          "value": 2,
+                          "code": "2"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "category": "jsexpression",
+                "expType": "FunctionCall",
+                "line": 2,
+                "column": 15,
+                "bound": true
+              }
+            ],
+            "line": 2,
+            "column": 8
+          }
+        ],
+        "line": 2,
+        "column": 3
+      },
+      {"type": "text", "value": "hello ", "line": 3, "column": 5},
+      {"type": "endelement", "name": "div", "line": 4, "column": 3}
+    ],
+    "closed": true,
+    "endLine": 5
+  }
+]
+
+##### Syntax Tree:
+[
+  {
+    "type": "template","name": "test","args": ["person"],"export": false,"startLine": 1,"endLine": 5,
+    "content": [
+      {
+        "type": "element",
+        "name": "div",
+        "closed": false,
+        "attributes": [
+          {
+            "type": "expression",
+            "category": "functionref",
+            "bound": true,
+            "path": [ "_foo" ],
+            "args": [
+              {
+                "type": "expression",
+                "category": "functionref",
+                "path": [ "_bar" ],
+                "args": [
+                  {
+                    "type": "expression",
+                    "category": "jsexpression",
+                    "objectrefs": [
+                      {
+                        "type": "expression",
+                        "category": "objectref",
+                        "path": [ "person", "name" ]
+                      }
+                    ],
+                    "code": "(a0 + \"!\")"
+                  },
+                  {
+                    "type": "expression",
+                    "category": "jsexpression",
+                    "objectrefs": [],
+                    "code": "(1 + 2)"
+                  }
+                ]
+              }
+            ],
+            "line": 2,
+            "column": 15,
+            "name": "title"
+          }
+        ],
+        "content": [{"type": "text","value": "hello "}]
+      }
+    ]
+  }
+]
+
+
+##### Template Code
+test=[
+    n.elt("div",{
+        e1:[4,1,_foo,1,2],
+        e2:[4,1,_bar,1,3,1,5],
+        e3:[6,function(a0) {return (a0 + "!");},4],
+        e4:[1,2,"person","name"],
+        e5:[6,function() {return (1 + 2);}]
+    },{
+        "title":["",1]
+    },0,[
+        n.$text(0,["hello "])
+    ])
+]

--- a/public/test/compiler/samples/jsexpression16.txt
+++ b/public/test/compiler/samples/jsexpression16.txt
@@ -1,0 +1,158 @@
+##### Template:
+# template test(person)
+  <div title="{person.name+"!"|bar:1+2|foo}">
+    hello
+  </div>
+# /template
+
+##### Parsed Tree:
+[
+  {
+    "type": "template","name": "test","args": ["person"],"line": 1,"column": 1,
+    "content": [
+      {
+        "type": "element",
+        "name": "div",
+        "closed": false,
+        "attributes": [
+          {
+            "type": "attribute",
+            "name": "title",
+            "value": [
+              {
+                "type": "expression",
+                "operator": "+",
+                "left": {
+                  "type": "PropertyAccess",
+                  "base": {"type": "Variable","name": "person","code": "person"},
+                  "name": "name",
+                  "code": "person.name"
+                },
+                "right": {
+                  "type": "expression",
+                  "category": "string",
+                  "value": "!",
+                  "code": "!"
+                },
+                "category": "jsexpression",
+                "expType": "BinaryExpression",
+                "line": 2,
+                "column": 15,
+                "pipes": [
+                  {
+                    "fnexpr": {"type": "Variable","name": "bar","code": "bar"},
+                    "args": [
+                      {
+                        "type": "BinaryExpression",
+                        "operator": "+",
+                        "left": {
+                          "type": "expression",
+                          "category": "number",
+                          "value": 1,
+                          "code": "1"
+                        },
+                        "right": {
+                          "type": "expression",
+                          "category": "number",
+                          "value": 2,
+                          "code": "2"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "fnexpr": {
+                      "type": "Variable",
+                      "name": "foo",
+                      "code": "foo"
+                    },
+                    "args": []
+                  }
+                ],
+                "bound": true
+              }
+            ],
+            "line": 2,
+            "column": 8
+          }
+        ],
+        "line": 2,
+        "column": 3
+      },
+      {"type": "text", "value": "hello ", "line": 3, "column": 5},
+      {"type": "endelement", "name": "div", "line": 4, "column": 3}
+    ],
+    "closed": true,
+    "endLine": 5
+  }
+]
+
+
+##### Syntax Tree:
+[
+  {
+    "type": "template","name": "test","args": ["person"],"export": false,"startLine": 1,"endLine": 5,
+    "content": [
+      {
+        "type": "element",
+        "name": "div",
+        "closed": false,
+        "attributes": [
+          {
+            "type": "expression",
+            "category": "functionref",
+            "bound": true,
+            "path": [ "_foo" ],
+            "args": [
+              {
+                "type": "expression",
+                "category": "functionref",
+                "path": [ "_bar" ],
+                "args": [
+                  {
+                    "type": "expression",
+                    "category": "jsexpression",
+                    "objectrefs": [
+                      {
+                        "type": "expression",
+                        "category": "objectref",
+                        "path": [ "person", "name" ]
+                      }
+                    ],
+                    "code": "(a0 + \"!\")"
+                  },
+                  {
+                    "type": "expression",
+                    "category": "jsexpression",
+                    "objectrefs": [],
+                    "code": "(1 + 2)"
+                  }
+                ]
+              }
+            ],
+            "line": 2,
+            "column": 15,
+            "name": "title"
+          }
+        ],
+        "content": [{"type": "text","value": "hello "}]
+      }
+    ]
+  }
+]
+
+
+##### Template Code
+test=[
+    n.elt("div",{
+        e1:[4,1,_foo,1,2],
+        e2:[4,1,_bar,1,3,1,5],
+        e3:[6,function(a0) {return (a0 + "!");},4],
+        e4:[1,2,"person","name"],
+        e5:[6,function() {return (1 + 2);}]
+    },{
+        "title":["",1]
+    },0,[
+        n.$text(0,["hello "])
+    ])
+]

--- a/public/test/compiler/samples/jsexpression17.txt
+++ b/public/test/compiler/samples/jsexpression17.txt
@@ -1,0 +1,21 @@
+##### Template:
+# template test(person)
+  {if person.name|acceptEmpty}
+    hello
+  {/if}
+# /template
+
+##### Parsed Tree:
+"skip"
+
+##### Syntax Tree:
+"skip"
+
+##### Template Code
+test=[
+  n.$if({
+    e1:[4,1,_acceptEmpty,1,2],
+    e2:[1,2,"person","name"]
+  },1,[n.$text(0,["hello "])])
+]
+

--- a/public/test/compiler/samples/jsexpression18.txt
+++ b/public/test/compiler/samples/jsexpression18.txt
@@ -1,0 +1,29 @@
+##### Template:
+# template test(person)
+  {foreach p in person.list|orderBy:"name"}
+    {p.name}
+  {/foreach}
+# /template
+
+##### Parsed Tree:
+"skip"
+
+##### Syntax Tree:
+"skip"
+
+##### Template Code
+test=[
+  n.$foreach(
+    {
+      e1:[4,1,_orderBy,1,2,0,"name"],
+      e2:[1,2,"person","list"]
+    },
+    "p_key",
+    "p",
+    0,
+    1,
+    [
+      n.$text({e1:[1,2,"p","name"]},["",1," "])
+    ]
+  )
+]

--- a/public/test/compiler/samples/let3.txt
+++ b/public/test/compiler/samples/let3.txt
@@ -1,0 +1,28 @@
+##### Template:
+# template test(foo)
+  <div class="foo">
+    // Some comment
+    {let aVarName = new Foo(), anotherName = new foo.Bar()}
+  </div>
+# /template
+
+##### Parsed Tree
+"skip"
+
+##### Syntax Tree
+"skip"
+    
+##### Template Code
+test=[
+  n.elt(
+    "div",0,{"class":"foo"},0,[
+      n.$text(0,[" "]),
+      n.let({
+        e1:[6,function(a0) {return new a0();},2],
+        e2:[2,1,_Foo],
+        e3:[6,function(a0) {return new a0();},4],
+        e4:[1,2,"foo","Bar"]
+      },['aVarName',1,'anotherName',3])
+    ],1
+  )
+]

--- a/public/test/compiler/samples/let4.txt
+++ b/public/test/compiler/samples/let4.txt
@@ -1,0 +1,28 @@
+##### Template:
+# template test(foo)
+  <div class="foo">
+    {let val = new Foo("a",123,blah(1+foo.value))}
+  </div>
+# /template
+
+##### Parsed Tree
+"skip"
+
+##### Syntax Tree
+"skip"
+    
+##### Template Code
+test=[
+  n.elt(
+    "div",0,{"class":"foo"},0,[
+      n.let({
+        e1:[6,function(a0,a1) {return new a0("a",123,a1);},2,3],
+        e2:[2,1,_Foo],
+        e3:[4,1,_blah,1,4],
+        e4:[6,function(a0) {return (1 + a0);},5],
+        e5:[1,2,"foo","value"]
+      },['val',1])
+    ],
+    1
+  )
+]

--- a/public/test/compiler/tests.js
+++ b/public/test/compiler/tests.js
@@ -75,7 +75,7 @@ describe('Block Parser: ', function () {
             assert.equal(r.errors.length, 0, "No compilation errors");
 
             for (var k in sample.codeFragments) {
-                //console.log("compilation result ["+k+"]\n\n"+r.codeFragments[k]+"\n\n");
+                // console.log("compilation result ["+k+"]\n\n"+r.codeFragments[k]+"\n\n");
 
                 // validate generated code
                 if (!r.codeFragments)
@@ -89,7 +89,7 @@ describe('Block Parser: ', function () {
     };
 
     var samples = ut.getSampleNames(__dirname + "/samples");
-    //samples=["foreach4"];
+    //samples=["let4"];
 
     for (var i = 0, sz = samples.length; sz > i; i++) {
         // create one test for each sample

--- a/public/test/rt/foreach.spec.hsp
+++ b/public/test/rt/foreach.spec.hsp
@@ -17,7 +17,8 @@
 var hsp=require("hsp/rt"),
     json=require("hsp/json"),
     doc=require("hsp/document"),
-    ht=require("hsp/utils/hashtester");
+    ht=require("hsp/utils/hashtester"),
+    klass=require("hsp/klass");
 
 # template test1(label,names)
     {foreach (name in names)}
@@ -90,6 +91,66 @@ var items=[
             {item.value}
         </div>
     {/foreach}
+# /template
+
+var Sorter=klass({
+    $constructor:function(property) {
+        this.ascending=true;
+        this.pp=property;
+    },
+    sort:function(array) {
+        // copy array
+        var arr=[], pp=this.pp, ascending=this.ascending;
+        for (var i=0,sz=array.length;sz>i;i++) {
+            arr[i]=array[i];
+        }
+        // sort
+        arr.sort(function (a,b) {
+            if (a[pp]>b[pp]) {
+                return ascending? 1 : -1;
+            } else if (a[pp]==b[pp]) {
+                return 0;
+            } else {
+                return ascending? -1 : 1;
+            }
+        });
+        return arr;
+    },
+    toggleOrder:function() {
+        this.ascending=!this.ascending;
+    }
+});
+
+# template test8(d)
+    <div class="section2">
+        {let fnSorter=new Sorter("firstName")}
+        <ol>
+            {foreach p in d.persons|fnSorter.sort}
+                <li>
+                    {p.firstName} {p.lastName}
+                </li>
+            {/foreach}
+        </ol>
+        <a class="toggle" onclick="{fnSorter.toggleOrder()}">
+            Toggle sort order (current: {fnSorter.ascending? "ascending" : "descending"})
+        </a>
+    </div>
+# /template
+
+# template test9(d,ppName)
+    <div class="section2">
+        {let fnSorter=new Sorter("firstName")}
+        <ol>
+            {foreach p in d[ppName]|fnSorter.sort}
+                <li>
+                    {p.firstName} {p.lastName}
+                </li>
+            {/foreach}
+        </ol>
+        <a class="toggle" onclick="{fnSorter.toggleOrder()}">
+            Toggle sort order (current: {fnSorter.ascending? "ascending" : "descending"})
+        </a>
+    </div>
 # /template
 
 describe("ForEach Node", function () {
@@ -578,6 +639,113 @@ describe("ForEach Node", function () {
 
         // no binding - so nbr of items should be the same
         expect(h(".itm").length).to.equal(2);
+
+        h.$dispose();
+    });
+
+    it("validates collection sorting through pipe expression", function() {
+        var h=ht.newTestContext();
+        var data={
+            msg:"Hello Simpsons!",
+            persons:[
+                {firstName:"Homer",lastName:"Simpsons"},
+                {firstName:"Marge",lastName:"Simpsons"},
+                {firstName:"Bart"},
+                {firstName:"Lisa"},
+                {firstName:"Maggy"}
+            ]
+        };
+        test8(data).render(h.container);
+
+        expect(h("li").length).to.equal(5);
+
+        expect(h("li").item(0).text()).to.equal("Bart  ");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
+        expect(h("li").item(2).text()).to.equal("Lisa  ");
+        expect(h("li").item(3).text()).to.equal("Maggy  ");
+        expect(h("li").item(4).text()).to.equal("Marge Simpsons ");
+
+        // toggle display
+        h("a.toggle").click();
+
+        expect(h("li").item(4).text()).to.equal("Bart  ");
+        expect(h("li").item(3).text()).to.equal("Homer Simpsons ");
+        expect(h("li").item(2).text()).to.equal("Lisa  ");
+        expect(h("li").item(1).text()).to.equal("Maggy  ");
+        expect(h("li").item(0).text()).to.equal("Marge Simpsons ");
+
+        // toggle back
+        h("a.toggle").click();
+
+        expect(h("li").item(0).text()).to.equal("Bart  ");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
+        expect(h("li").item(2).text()).to.equal("Lisa  ");
+        expect(h("li").item(3).text()).to.equal("Maggy  ");
+        expect(h("li").item(4).text()).to.equal("Marge Simpsons ");
+
+        // modify collection
+        data.persons.splice(1,0,{firstName:"Kevin"});
+        h.refresh();
+
+        expect(h("li").length).to.equal(6);
+        expect(h("li").item(0).text()).to.equal("Bart  ");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
+        expect(h("li").item(2).text()).to.equal("Kevin  ");
+        expect(h("li").item(3).text()).to.equal("Lisa  ");
+
+        h.$dispose();
+    });
+
+
+    it("validates collection sorting through pipe expression and dynamic data reference", function() {
+        var h=ht.newTestContext();
+        var data={
+            msg:"Hello Simpsons!",
+            persons:[
+                {firstName:"Homer",lastName:"Simpsons"},
+                {firstName:"Marge",lastName:"Simpsons"},
+                {firstName:"Bart"},
+                {firstName:"Lisa"},
+                {firstName:"Maggy"}
+            ]
+        };
+        test9(data,"persons").render(h.container);
+
+        expect(h("li").length).to.equal(5);
+
+        expect(h("li").item(0).text()).to.equal("Bart  ");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
+        expect(h("li").item(2).text()).to.equal("Lisa  ");
+        expect(h("li").item(3).text()).to.equal("Maggy  ");
+        expect(h("li").item(4).text()).to.equal("Marge Simpsons ");
+
+        // toggle display
+        h("a.toggle").click();
+
+        expect(h("li").item(4).text()).to.equal("Bart  ");
+        expect(h("li").item(3).text()).to.equal("Homer Simpsons ");
+        expect(h("li").item(2).text()).to.equal("Lisa  ");
+        expect(h("li").item(1).text()).to.equal("Maggy  ");
+        expect(h("li").item(0).text()).to.equal("Marge Simpsons ");
+
+        // toggle back
+        h("a.toggle").click();
+
+        expect(h("li").item(0).text()).to.equal("Bart  ");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
+        expect(h("li").item(2).text()).to.equal("Lisa  ");
+        expect(h("li").item(3).text()).to.equal("Maggy  ");
+        expect(h("li").item(4).text()).to.equal("Marge Simpsons ");
+
+        // modify collection
+        data.persons.splice(1,0,{firstName:"Kevin"});
+        h.refresh();
+
+        expect(h("li").length).to.equal(6);
+        expect(h("li").item(0).text()).to.equal("Bart  ");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
+        expect(h("li").item(2).text()).to.equal("Kevin  ");
+        expect(h("li").item(3).text()).to.equal("Lisa  ");
 
         h.$dispose();
     });


### PR DESCRIPTION
This PR implements the proposal discussed in issue #123.

I had to remove the JavaScript bitwise or operator (i.e. `|`) from hashspace expressions to be able to use the pipe as 'modifier operator' - but as it is a standard statement in other template languages (e.g. smarty or angular), I preferred to keep the pipe for modifiers and discard the bitwise or operator.

For the rest, I think all is in the sample:

```
var klass=require("hsp/klass");

function changeCase(s,arg) {
    if (arg==="upper") {
        return (""+s).toUpperCase();
    } else if (arg==="lower") {
        return (""+s).toLowerCase();
    } 
    return s;
}

var Sorter=klass({
    $constructor:function(property) {
        this.ascending=true;
        this.pp=property;
    },
    sort:function(array) {
        // copy array
        var arr=[], pp=this.pp, ascending=this.ascending;
        for (var i=0,sz=array.length;sz>i;i++) {
            arr[i]=array[i];
        }
        // sort
        arr.sort(function (a,b) {
            if (a[pp]>b[pp]) {
                return ascending? 1 : -1;
            } else if (a[pp]==b[pp]) {
                return 0;
            } else {
                return ascending? -1 : 1;
            }
        });
        return arr;
    },
    toggleOrder:function() {
        this.ascending=!this.ascending;
    }
})

# template sample(d)
    <div class="section2">
        Message in capital letters:
        <span class="textvalue">{d.msg|changeCase:"upper"}</span><br/>
        Message in lower case:
        <span class="textvalue">{d.msg|changeCase:"lower"}</span>
    </div>
    <div class="section2">
        {let fnSorter=new Sorter("firstName")}
        Sorted list:
        <ol>
            {foreach p in d.persons|fnSorter.sort}
                <li>
                    {p.firstName} {p.lastName}
                </li>
            {/foreach}
        </ol>
        <a onclick="{fnSorter.toggleOrder()}">
            Toggle sort order (current: {fnSorter.ascending? "ascending" : "descending"})
        </a>
    </div>
# /template

var data={
    msg:"Hello Simpsons!",
    persons:[
        {firstName:"Homer",lastName:"Simpsons"},
        {firstName:"Marge",lastName:"Simpsons"},
        {firstName:"Bart"},
        {firstName:"Lisa"},
        {firstName:"Maggy"}
    ]
};

sample(data).render("output");
```

PS: I forgot to mention that operators are applied in the same order as they are written - so that

```
 {foo.bar|upper|spacify} 
 // is equivalent to
 {spacify(upper(foo.bar))}
```
