### PR TITLE
fix issue #156

### DIFF
--- a/hsp/rt/$root.js
+++ b/hsp/rt/$root.js
@@ -217,8 +217,8 @@ var $RootNode = klass({
     updateObjectObservers : function (ni) {
         if (ni.obsPairs) {
             this.rmAllObjectObservers(ni);
-            this.createExpressionObservers(ni);
         }
+        this.createExpressionObservers(ni);
     },
 
     /**

--- a/public/test/rt/exprbinding.spec.hsp
+++ b/public/test/rt/exprbinding.spec.hsp
@@ -43,6 +43,21 @@ function changeValue (data,val) {
    <#header document="{data.document}" />
 # /template
 
+
+# template title(document)
+  {if document && document.title}
+    {document.title}
+  {else}
+    No title
+  {/if}
+# /template
+
+# template test3(data)
+  <div class="content">
+    <#title document="{data.document}" />
+  </div>
+# /template
+
 describe("Expression Bindings", function () {
     var INPUT1=".in1", INPUT2=".in2";
 
@@ -105,6 +120,31 @@ describe("Expression Bindings", function () {
         delete dm.document;
         h.refresh();
         expect(h(".title").text()).to.equal("Untitled document ");
+
+        h.$dispose();
+    });
+
+    it("validates expression handling when observable pairs are set to null", function() {
+        var h=ht.newTestContext(), dm={};
+        test3(dm).render(h.container);
+
+        expect(h("div.content").text()).to.equal("No title ");
+
+        // create document
+        h.$set(dm,"document",{title:"foo"});
+        expect(h("div.content").text()).to.equal("foo ");
+
+        // change title
+        h.$set(dm.document,"title","f");
+        expect(h("div.content").text()).to.equal("f ");
+
+        // empty title
+        h.$set(dm.document,"title","");
+        expect(h("div.content").text()).to.equal("No title ");
+
+        // change title
+        h.$set(dm.document,"title","bar");
+        expect(h("div.content").text()).to.equal("bar ");
 
         h.$dispose();
     });


### PR DESCRIPTION
The previous code was assuming that observable pairs necessarily exist when there are things to observe - but this may be false when the targeted objects are set to null, like in the issue sample..

@divdavem nice catch - thanks!
