### PR TITLE
Removes unnecessary global var access when cpt path is in local scope

### DIFF
--- a/hsp/compiler/jsgenerator/processors.js
+++ b/hsp/compiler/jsgenerator/processors.js
@@ -292,9 +292,16 @@ exports["component"] = function (node, walker) {
     var generatedNode = elementOrComponent(node, walker);
     var path = node.ref.path;
 
-    walker.addGlobalRef(path[0]);
-
-    return ['n.cpt([_', path[0], ',"', path.join('","'), '"],', generatedNode, ')'].join('');
+    // TODO: a path is a special case of an expression
+    // components should be refactored to use expressions
+    var globalRoot, root = path[0];
+    if (walker.isInScope(root)) {
+        globalRoot = 'null';
+    } else {
+        walker.addGlobalRef(root);
+        globalRoot = '_' + root;
+    }
+    return ['n.cpt([', globalRoot, ',"', path.join('","'), '"],', generatedNode, ')'].join('');
 };
 
 /**

--- a/public/test/compiler/samples/component8.txt
+++ b/public/test/compiler/samples/component8.txt
@@ -1,0 +1,15 @@
+##### Template:
+# template test using c:Ctrl
+   <#c.tpl />
+# /template
+
+##### Parsed Tree:
+"skip"
+
+##### Syntax Tree:
+"skip"
+
+##### Template Code:
+test=[
+  n.cpt([null,"c","tpl"],0,0,0)
+]


### PR DESCRIPTION
Consider the following template:

```
# template myTpl using c:Ctrl
  <#c.tpl />
# /template
```

Before this pull request, the compiler was generating the following code:

``` js
var myTpl = require("hsp/rt").template({ctl:[Ctrl,"Ctrl"],ref:"c"}, function(n){
var _c;try {_c=c} catch(e) {};
return [n.cpt([_c,"c","tpl"],0,0,0)];
});
```

Note the unexpected access to the global `c` variable, which is stored in `_c` in a `try`...`catch` block.

As we know the `c` variable is in the scope in this case, this pull request changes the compiler to generate the following code instead:

``` js
var myTpl = require("hsp/rt").template({ctl:[Ctrl,"Ctrl"],ref:"c"}, function(n){
return [n.cpt([null,"c","tpl"],0,0,0)];
});
```
