### PR TITLE
fix #152 transpiler fails with (obj1.prop1 = value1).prop2 = value2

### DIFF
--- a/hsp/transpiler/formatAST.js
+++ b/hsp/transpiler/formatAST.js
@@ -34,9 +34,12 @@ module.exports = function (ast, fileContent, options) {
     }
 
     function walkFunction (node, descend) {
+        var newStart = (nextStart === null);
         var formatInfo = node.formatInfo;
         if (formatInfo) {
-            continueUntil(formatInfo.originalStartPos);
+            if (!newStart) {
+                continueUntil(formatInfo.originalStartPos);
+            }
             out.push(formatInfo.before);
             var middle = formatInfo.middle;
             for (var i = 0, l = middle.length; i < l; i++) {
@@ -46,11 +49,12 @@ module.exports = function (ast, fileContent, options) {
                 walkNode(middle[i]);
             }
             out.push(formatInfo.after);
-            restartFrom(formatInfo.originalEndPos);
-        } else if (!(node.start && node.end)) {
+            if (!newStart) {
+                restartFrom(formatInfo.originalEndPos);
+            }
+        } else if (newStart && !(node.start && node.end)) {
             out.push(node.print_to_string());
         } else {
-            var newStart = (nextStart === null);
             if (newStart) {
                 restartFrom(node.start.pos);
             }

--- a/test/transpiler/processString.spec.js
+++ b/test/transpiler/processString.spec.js
@@ -54,6 +54,8 @@ describe("Transpiler", function () {
             a.i = -1;
             a.i ^= 1;
             a.i |= 1;
+            a.j = a.k = 7;
+            (a.l = {}).m = 12;
         };
         var result = processString("(" + mySourceFunction.toString() + ")");
         assert.equal(result.changed, true);
@@ -186,6 +188,21 @@ describe("Transpiler", function () {
                     name : "i",
                     newValue : -1,
                     oldValue : -2
+                }, {
+                    type : "new",
+                    name : "k",
+                    newValue : 7,
+                    oldValue : undefined
+                }, {
+                    type : "new",
+                    name : "j",
+                    newValue : 7,
+                    oldValue : undefined
+                }, {
+                    type : "new",
+                    name : "l",
+                    newValue : {},
+                    oldValue : undefined
                 }];
         var observer = function (chgList) {
             assert.equal(chgList.length, 1);


### PR DESCRIPTION
This pull request fixes issue #152.
