### PR TITLE
Excluding the transpiler from karma.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -57,6 +57,7 @@ module.exports = function (grunt) {
         ],
         exclude: [
           'hsp/compiler/**/*.js',
+          'hsp/transpiler/**/*.js',
           'test/transpiler/**/*.spec.js',
           'test/compiler/**/*.spec.js'
         ],


### PR DESCRIPTION
This fixes the issue with the transpiler appearing twice with different coverage results in the report on coveralls.io.

Cf here: https://coveralls.io/builds/776554

The following files appeared twice
./hsp/transpiler/processString.js
./hsp/transpiler/processAST.js
./hsp/transpiler/formatAST.js
