### PR TITLE
tests: add default trim to the text() helper

### DIFF
--- a/hsp/utils/hashtester.js
+++ b/hsp/utils/hashtester.js
@@ -34,10 +34,13 @@ var SelectionWrapper=klass({
     },
     /**
      * Return the textual content of the selection. Will recursively go through all DOM sub-nodes
-     * and concatenate the different text node content
+     * and concatenate the different text node content. By default will trim the returned text.
+     *
+     * @param {Boolean} trim the returned text - true by default
      **/
-    text:function() {
-        return this.$selection.text();
+    text:function(trim) {
+        var text = this.$selection.text();
+        return trim === false ? text : $.trim(text);
     },
     /**
      * Return the selection corresponding to the nth element in the selection

--- a/test/rt/cptattelements1.spec.hsp
+++ b/test/rt/cptattelements1.spec.hsp
@@ -129,12 +129,12 @@ describe("Component attribute elements (1)", function () {
     var body=h(BODY);
     expect(head.length).to.equal(0);
     expect(body.length).to.equal(1);
-    expect(body.text()).to.equal("Hello World! ");
+    expect(body.text()).to.equal("Hello World!");
 
     // dynamic property change
     h.$set(m,"text","Hello folks");
 
-    expect(body.text()).to.equal("Hello folks! ");
+    expect(body.text()).to.equal("Hello folks!");
 
     h.$dispose();
   });

--- a/test/rt/exprbinding.spec.hsp
+++ b/test/rt/exprbinding.spec.hsp
@@ -106,20 +106,20 @@ describe("Expression Bindings", function () {
         var h=ht.newTestContext(), dm={document:{title:"No title"}};
         test2(dm).render(h.container);
 
-        expect(h(".title").text()).to.equal("No title ");
+        expect(h(".title").text()).to.equal("No title");
 
         // change data
         h.$set(dm,"document",null);
-        expect(h(".title").text()).to.equal("Untitled document ");
+        expect(h(".title").text()).to.equal("Untitled document");
 
         // set back
         h.$set(dm,"document",{title:"Doc 1"});
-        expect(h(".title").text()).to.equal("Doc 1 ");
+        expect(h(".title").text()).to.equal("Doc 1");
 
         // delete data
         delete dm.document;
         h.refresh();
-        expect(h(".title").text()).to.equal("Untitled document ");
+        expect(h(".title").text()).to.equal("Untitled document");
 
         h.$dispose();
     });
@@ -128,23 +128,23 @@ describe("Expression Bindings", function () {
         var h=ht.newTestContext(), dm={};
         test3(dm).render(h.container);
 
-        expect(h("div.content").text()).to.equal("No title ");
+        expect(h("div.content").text()).to.equal("No title");
 
         // create document
         h.$set(dm,"document",{title:"foo"});
-        expect(h("div.content").text()).to.equal("foo ");
+        expect(h("div.content").text()).to.equal("foo");
 
         // change title
         h.$set(dm.document,"title","f");
-        expect(h("div.content").text()).to.equal("f ");
+        expect(h("div.content").text()).to.equal("f");
 
         // empty title
         h.$set(dm.document,"title","");
-        expect(h("div.content").text()).to.equal("No title ");
+        expect(h("div.content").text()).to.equal("No title");
 
         // change title
         h.$set(dm.document,"title","bar");
-        expect(h("div.content").text()).to.equal("bar ");
+        expect(h("div.content").text()).to.equal("bar");
 
         h.$dispose();
     });

--- a/test/rt/fnexpressions.spec.hsp
+++ b/test/rt/fnexpressions.spec.hsp
@@ -159,15 +159,15 @@ describe("Function expressions", function () {
         };
         test4(d).render(h.container);
 
-        expect(h(C).text()).to.equal("[hello world]! ");
+        expect(h(C).text()).to.equal("[hello world]!");
 
         // change arg
         h.$set(d,"msg2","earth");
-        expect(h(C).text()).to.equal("[hello earth]! ");
+        expect(h(C).text()).to.equal("[hello earth]!");
 
         // trigger if
         h.$set(d,"showEndText",true);
-        expect(h(C).text()).to.equal("[hello earth]! *123* ");
+        expect(h(C).text()).to.equal("[hello earth]! *123*");
 
         h.$dispose();
     });

--- a/test/rt/foreach.spec.hsp
+++ b/test/rt/foreach.spec.hsp
@@ -659,39 +659,39 @@ describe("ForEach Node", function () {
 
         expect(h("li").length).to.equal(5);
 
-        expect(h("li").item(0).text()).to.equal("Bart  ");
-        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
-        expect(h("li").item(2).text()).to.equal("Lisa  ");
-        expect(h("li").item(3).text()).to.equal("Maggy  ");
-        expect(h("li").item(4).text()).to.equal("Marge Simpsons ");
+        expect(h("li").item(0).text()).to.equal("Bart");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons");
+        expect(h("li").item(2).text()).to.equal("Lisa");
+        expect(h("li").item(3).text()).to.equal("Maggy");
+        expect(h("li").item(4).text()).to.equal("Marge Simpsons");
 
         // toggle display
         h("a.toggle").click();
 
-        expect(h("li").item(4).text()).to.equal("Bart  ");
-        expect(h("li").item(3).text()).to.equal("Homer Simpsons ");
-        expect(h("li").item(2).text()).to.equal("Lisa  ");
-        expect(h("li").item(1).text()).to.equal("Maggy  ");
-        expect(h("li").item(0).text()).to.equal("Marge Simpsons ");
+        expect(h("li").item(4).text()).to.equal("Bart");
+        expect(h("li").item(3).text()).to.equal("Homer Simpsons");
+        expect(h("li").item(2).text()).to.equal("Lisa");
+        expect(h("li").item(1).text()).to.equal("Maggy");
+        expect(h("li").item(0).text()).to.equal("Marge Simpsons");
 
         // toggle back
         h("a.toggle").click();
 
-        expect(h("li").item(0).text()).to.equal("Bart  ");
-        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
-        expect(h("li").item(2).text()).to.equal("Lisa  ");
-        expect(h("li").item(3).text()).to.equal("Maggy  ");
-        expect(h("li").item(4).text()).to.equal("Marge Simpsons ");
+        expect(h("li").item(0).text()).to.equal("Bart");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons");
+        expect(h("li").item(2).text()).to.equal("Lisa");
+        expect(h("li").item(3).text()).to.equal("Maggy");
+        expect(h("li").item(4).text()).to.equal("Marge Simpsons");
 
         // modify collection
         data.persons.splice(1,0,{firstName:"Kevin"});
         h.refresh();
 
         expect(h("li").length).to.equal(6);
-        expect(h("li").item(0).text()).to.equal("Bart  ");
-        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
-        expect(h("li").item(2).text()).to.equal("Kevin  ");
-        expect(h("li").item(3).text()).to.equal("Lisa  ");
+        expect(h("li").item(0).text()).to.equal("Bart");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons");
+        expect(h("li").item(2).text()).to.equal("Kevin");
+        expect(h("li").item(3).text()).to.equal("Lisa");
 
         h.$dispose();
     });
@@ -713,39 +713,39 @@ describe("ForEach Node", function () {
 
         expect(h("li").length).to.equal(5);
 
-        expect(h("li").item(0).text()).to.equal("Bart  ");
-        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
-        expect(h("li").item(2).text()).to.equal("Lisa  ");
-        expect(h("li").item(3).text()).to.equal("Maggy  ");
-        expect(h("li").item(4).text()).to.equal("Marge Simpsons ");
+        expect(h("li").item(0).text()).to.equal("Bart");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons");
+        expect(h("li").item(2).text()).to.equal("Lisa");
+        expect(h("li").item(3).text()).to.equal("Maggy");
+        expect(h("li").item(4).text()).to.equal("Marge Simpsons");
 
         // toggle display
         h("a.toggle").click();
 
-        expect(h("li").item(4).text()).to.equal("Bart  ");
-        expect(h("li").item(3).text()).to.equal("Homer Simpsons ");
-        expect(h("li").item(2).text()).to.equal("Lisa  ");
-        expect(h("li").item(1).text()).to.equal("Maggy  ");
-        expect(h("li").item(0).text()).to.equal("Marge Simpsons ");
+        expect(h("li").item(4).text()).to.equal("Bart");
+        expect(h("li").item(3).text()).to.equal("Homer Simpsons");
+        expect(h("li").item(2).text()).to.equal("Lisa");
+        expect(h("li").item(1).text()).to.equal("Maggy");
+        expect(h("li").item(0).text()).to.equal("Marge Simpsons");
 
         // toggle back
         h("a.toggle").click();
 
-        expect(h("li").item(0).text()).to.equal("Bart  ");
-        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
-        expect(h("li").item(2).text()).to.equal("Lisa  ");
-        expect(h("li").item(3).text()).to.equal("Maggy  ");
-        expect(h("li").item(4).text()).to.equal("Marge Simpsons ");
+        expect(h("li").item(0).text()).to.equal("Bart");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons");
+        expect(h("li").item(2).text()).to.equal("Lisa");
+        expect(h("li").item(3).text()).to.equal("Maggy");
+        expect(h("li").item(4).text()).to.equal("Marge Simpsons");
 
         // modify collection
         data.persons.splice(1,0,{firstName:"Kevin"});
         h.refresh();
 
         expect(h("li").length).to.equal(6);
-        expect(h("li").item(0).text()).to.equal("Bart  ");
-        expect(h("li").item(1).text()).to.equal("Homer Simpsons ");
-        expect(h("li").item(2).text()).to.equal("Kevin  ");
-        expect(h("li").item(3).text()).to.equal("Lisa  ");
+        expect(h("li").item(0).text()).to.equal("Bart");
+        expect(h("li").item(1).text()).to.equal("Homer Simpsons");
+        expect(h("li").item(2).text()).to.equal("Kevin");
+        expect(h("li").item(3).text()).to.equal("Lisa");
 
         h.$dispose();
     });

--- a/test/rt/let.spec.hsp
+++ b/test/rt/let.spec.hsp
@@ -71,14 +71,14 @@ describe("Let statement", function () {
         var h=ht.newTestContext(), d={value:"hello"};
         test1(d).render(h.container);
 
-        expect(h(".foo").text()).to.equal("Blah hello ");
-        expect(h(".bar").text()).to.equal("hello3AL ");
+        expect(h(".foo").text()).to.equal("Blah hello");
+        expect(h(".bar").text()).to.equal("hello3AL");
 
         // change value dynamically
         h.$set(d,"value","salut");
 
-        expect(h(".foo").text()).to.equal("Blah salut ");
-        expect(h(".bar").text()).to.equal("salut3AL ");
+        expect(h(".foo").text()).to.equal("Blah salut");
+        expect(h(".bar").text()).to.equal("salut3AL");
         expect(h.logs().length).to.equal(0);
         
         h.$dispose();
@@ -88,14 +88,14 @@ describe("Let statement", function () {
         var h=ht.newTestContext(), d={value:"Hello"};
         test2(d).render(h.container);
 
-        expect(h(".foo").text()).to.equal("Hello World ");
-        expect(h(".bar").text()).to.equal(" ");
+        expect(h(".foo").text()).to.equal("Hello World");
+        expect(h(".bar").text()).to.equal("");
 
         // change value dynamically
         h.$set(d,"value","How are you");
 
-        expect(h(".foo").text()).to.equal("How are you World ");
-        expect(h(".bar").text()).to.equal(" ");
+        expect(h(".foo").text()).to.equal("How are you World");
+        expect(h(".bar").text()).to.equal("");
         expect(h.logs().length).to.equal(0);
     });
 
@@ -103,17 +103,17 @@ describe("Let statement", function () {
         var h=ht.newTestContext(), d={condition:true,value1:"Hello",value2:"How are you?"};
         test3(d).render(h.container);
 
-        expect(h(".foo").text()).to.equal("x: Hello World - y:  ");
+        expect(h(".foo").text()).to.equal("x: Hello World - y:");
 
         // change condition dynamically
         h.$set(d,"condition",false);
 
-        expect(h(".foo").text()).to.equal("x:  - y: How are you? ");
+        expect(h(".foo").text()).to.equal("x:  - y: How are you?");
 
         // change back
         h.$set(d,"condition",true);
 
-        expect(h(".foo").text()).to.equal("x: Hello World - y:  ");    
+        expect(h(".foo").text()).to.equal("x: Hello World - y:");
         expect(h.logs().length).to.equal(0);
     });
 

--- a/test/rt/log.spec.hsp
+++ b/test/rt/log.spec.hsp
@@ -47,7 +47,7 @@ describe("Log statement", function () {
         var h=ht.newTestContext();
         test1({value:123}).render(h.container);
 
-        expect(h(".foo").text()).to.equal("Blah ");
+        expect(h(".foo").text()).to.equal("Blah");
 
         expect(h.logs().length).to.equal(1);
         expect(h.logs(0).message).to.equal("123");
@@ -67,7 +67,7 @@ describe("Log statement", function () {
         var x;
         test2(m).render(h.container);
 
-        expect(h(".foo").text()).to.equal("... ");
+        expect(h(".foo").text()).to.equal("...");
 
         expect(h.logs().length).to.equal(1);
         expect(h.logs(0).message).to.equal('abc {bar:Array[3], foo:1}');

--- a/test/rt/subtemplates2.spec.hsp
+++ b/test/rt/subtemplates2.spec.hsp
@@ -88,19 +88,19 @@ describe("Dynamic template insertion", function () {
         test1(c).render(h.container);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentA - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentA - After");
 
         // change template dynamically
         h.$set(c,"tpl",contentB);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentB - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentB - After");
 
         // change template dynamically, again
         h.$set(c,"tpl",contentC);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentC - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentC - After");
         
         h.$dispose();
     });
@@ -110,25 +110,25 @@ describe("Dynamic template insertion", function () {
         test2(c).render(h.container);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentA - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentA - After");
 
         // change template dynamically
         h.$set(c.a.b,"tpl",contentB);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentB - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentB - After");
 
         // change path but not the template
         h.$set(c.a,"b",{tpl:contentB,foo:"bar"});
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentB - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentB - After");
 
         // change path and template
         h.$set(c.a,"b",{tpl:contentC,foo:"bar"});
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentC - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentC - After");
 
         h.$dispose();
     });
@@ -138,25 +138,25 @@ describe("Dynamic template insertion", function () {
         test3(c).render(h.container);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - contentA2: foo - After ");
+        expect(h(".content").text()).to.equal("Before - contentA2: foo - After");
 
         // change template dynamically
         h.$set(c,"tpl",contentB2);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - contentB2: foo - After ");
+        expect(h(".content").text()).to.equal("Before - contentB2: foo - After");
 
         // change txt value
         h.$set(c,"txt","bar");
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - contentB2: bar - After ");
+        expect(h(".content").text()).to.equal("Before - contentB2: bar - After");
         
         // change template again dynamically
         h.$set(c,"tpl",contentA2);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - contentA2: bar - After ");
+        expect(h(".content").text()).to.equal("Before - contentA2: bar - After");
 
         h.$dispose();
     });
@@ -166,13 +166,13 @@ describe("Dynamic template insertion", function () {
         test4(c).render(h.container);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentA - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentA - After");
 
         // change template dynamically
         h.$set(c,"tpl",contentB2);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - contentB2: hello - After ");
+        expect(h(".content").text()).to.equal("Before - contentB2: hello - After");
 
         h.$dispose();
     });
@@ -182,19 +182,19 @@ describe("Dynamic template insertion", function () {
         test5(c).render(h.container);
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentA - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentA - After");
 
         // change intermediate object in the template path
         h.$set(c,"a",{b:{tpl:contentB,foo:"bar"}});
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentB - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentB - After");
 
         // change path and template
         h.$set(c.a,"b",{tpl:contentC,foo:"bar"});
 
         expect(h.logs().length).to.equal(0);
-        expect(h(".content").text()).to.equal("Before - This is contentC - After ");
+        expect(h(".content").text()).to.equal("Before - This is contentC - After");
 
         h.$dispose();
     });


### PR DESCRIPTION
This PR adds the default `trim()` call to the hashtester's `.text()` helper method. This is avoids the need to mess with leading / trailing white-spaces in tests (check all the modified tests to see what I mean).
