### PR TITLE
tests: add test to samples - infrastructure

### DIFF
--- a/build/grunt/config-checkStyle.js
+++ b/build/grunt/config-checkStyle.js
@@ -33,6 +33,7 @@ module.exports = function (grunt) {
             files : {
                 src : [ 'docs/**/*.js',
                         '!docs/libs/**/*.js',
+                        '!docs/samples/**/*.spec.js',
                         '!docs/**/test/**/*.js' // the test for todomvc is in docs
                 ]
             },
@@ -60,7 +61,7 @@ module.exports = function (grunt) {
             }
         },
         test : {
-            src : ['test/**/*.js','docs/**/test/**/*.js'], // the test for todomvc is in docs
+            src : ['test/**/*.js', 'docs/samples/**/*.spec.js', 'docs/**/test/**/*.js'], // the test for todomvc is in docs
             options : {
                 "node" : true,
                 "globals" : {

--- a/docs/samples/clickhandler/clickhandler.hsp
+++ b/docs/samples/clickhandler/clickhandler.hsp
@@ -1,9 +1,9 @@
 var msg={text:""}, count=-1;
 
-# template message(msg)
+# export template message(msg)
     <div title="click me!" onclick="{changeMessage()}" onselectstart="return false">
-        {if msg.isWarning}<div class="warning">WARNING:&nbsp;</div>{/if}
-        {msg.text}
+        {if msg.isWarning}<span class="warning">WARNING:&nbsp;</span>{/if}
+        <span>{msg.text}</span>
     </div>
 # /template
 
@@ -12,7 +12,7 @@ function changeMessage() {
     switch(count%3) {
         case 0:
             msg.isWarning = false;
-            msg.text = "Click me to discover hashspace event hanlders";
+            msg.text = "Click me to discover hashspace event handlers";
             break;
         case 1:
             msg.text = "Well done - you called the event handler and updated the data model in a row!";
@@ -24,8 +24,11 @@ function changeMessage() {
     }
 }
 
+//export data to be available in test
+module.exports.msg = msg;
+
 // set a first message value
 changeMessage();
+
 // display the template in the #output div
 message(msg).render("output");
-

--- a/docs/samples/clickhandler/clickhandler.spec.js
+++ b/docs/samples/clickhandler/clickhandler.spec.js
@@ -1,0 +1,32 @@
+var hashTester = require('hsp/utils/hashtester');
+var messageSample = require('./clickhandler.hsp');
+
+describe('"Simple event handler" sample', function () {
+
+    var h;
+    beforeEach(function () {
+        h = hashTester.newTestContext();
+        messageSample.message(messageSample.msg).render(h.container);
+    });
+
+    afterEach(function () {
+        h.$dispose();
+    });
+
+    it('should render initial state', function () {
+        expect(h('div').text()).to.equal('Click me to discover hashspace event handlers');
+    });
+
+    it('should cycle through messages on click', function () {
+        h('div').click();
+        expect(h('div > span').text()).to
+            .equal('Well done - you called the event handler and updated the data model in a row!');
+
+        h('div').click();
+        expect(h('div > span.warning').text()).to.match(/WARNING/);
+        expect(h('div > span:eq(1)').text()).to.equal('If you click again you will be back to first step!');
+
+        h('div').click();
+        expect(h('div > span').text()).to.equal('Click me to discover hashspace event handlers');
+    });
+});

--- a/docs/samples/helloworld/hello.hsp
+++ b/docs/samples/helloworld/hello.hsp
@@ -1,5 +1,5 @@
 
-# template hello(name)
+# export template hello(name)
     <div class="msg">
         Hello {name}!
     </div>

--- a/docs/samples/helloworld/hello.spec.js
+++ b/docs/samples/helloworld/hello.spec.js
@@ -1,0 +1,19 @@
+var hashTester = require('hsp/utils/hashtester');
+var helloTpl = require('./hello.hsp').hello;
+
+describe('"Hello World" sample', function () {
+
+    var h;
+    beforeEach(function () {
+        h = hashTester.newTestContext();
+    });
+
+    afterEach(function () {
+        h.$dispose();
+    });
+
+    it('should render "Hello World" from a template', function () {
+        helloTpl('World').render(h.container);
+        expect(h('div.msg').text()).to.equal('Hello World!');
+    });
+});

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -51,6 +51,9 @@ module.exports = function (grunt) {
         files: [
           'hsp/**/*.js',
           'test/**/*.spec.*',
+          'docs/libs/Chart.min.js',
+          'docs/samples/*/*.hsp',
+          'docs/samples/*/*.spec.js',
           'node_modules/sinon/pkg/sinon-ie.js',
           'node_modules/jquery/dist/jquery.min.js',
           'node_modules/sinon/pkg/sinon-ie.js'
@@ -59,13 +62,16 @@ module.exports = function (grunt) {
           'hsp/compiler/**/*.js',
           'hsp/transpiler/**/*.js',
           'test/transpiler/**/*.spec.js',
-          'test/compiler/**/*.spec.js'
+          'test/compiler/**/*.spec.js',
+          'docs/samples/thirdpartycpts/**/*.*',
         ],
         preprocessors: {
           'hsp/**/*.js': ['commonjs'],
           'test/lib/*.js': ['commonjs'],
           'test/**/*.spec.js': ['commonjs'],
           'test/**/*.spec.hsp': ['hsp', 'commonjs'],
+          'docs/samples/*/*.hsp': ['hsp', 'commonjs'],
+          'docs/samples/*/*.spec.js': ['commonjs'],
           'node_modules/jquery/dist/jquery.min.js': ['commonjs']
         },
         commonjsPreprocessor: {
@@ -163,19 +169,12 @@ module.exports = function (grunt) {
             platform: 'Linux',
             version: '4.3'
           }
-        }
-        //logLevel: 'LOG_INFO'
+        },
+        logLevel: 'LOG_DEBUG'
       },
       unit: {
         singleRun: true,
-        preprocessors: {
-          'hsp/**/*.js': ['commonjs', 'coverage']
-        },
-        reporters: ['progress', 'coverage'],
-        coverageReporter: {
-          type : 'lcov',
-          dir : 'test-results/karma/'
-        }
+        reporters: ['progress', 'coverage']
       },
       tdd: {
         singleRun: false,
@@ -215,14 +214,16 @@ module.exports = function (grunt) {
         browserNoActivityTimeout: 20000,
         captureTimeout: 300000,
         browsers: ['SL_iOS_7', 'SL_Firefox', 'SL_Android_4.2', 'SL_Android_4.3', 'SL_IE_10', 'SL_IE_11', 'SL_Safari_6'],
-        reporters: ['dots', 'saucelabs']
+        reporters: ['dots', 'saucelabs'],
+        verbose: true
       },
       sauce: {
         singleRun: true,
         browserNoActivityTimeout: 20000,
         captureTimeout: 300000,
         browsers: ['SL_IE_8', 'SL_IE_9', 'SL_IE_10', 'SL_IE_11', 'SL_Safari_6', 'SL_Safari_7', 'SL_Firefox', 'SL_Chrome', 'SL_Android_4.0', 'SL_Android_4.1', 'SL_Android_4.2', 'SL_Android_4.3', 'SL_iOS_7'],
-        reporters: ['dots', 'saucelabs']
+        reporters: ['dots', 'saucelabs'],
+        verbose: true
       }
     },
     jscs: {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-markdown": "0.5.0",
     "load-grunt-tasks": "~0.2.1",
     "karma": "~0.12.0",
-    "karma-commonjs": "0.0.6",
+    "karma-commonjs": "~0.0.7",
     "karma-sauce-launcher": "~0.2.5",
     "karma-mocha": "~0.1.1",
     "karma-expect": "~1.0.0",


### PR DESCRIPTION
This is the first stab at introducing DOM-based unit test. There are only tests for 2 samples now, but opening this PR early on to:
- show which config changes would be needed
- discuss one of the not-so-nice effect connected with the fact that we've got `.render('output')` in each and every sample; this generates a warning in each test.

I had a short chat about this with @b-laporte today and we though of overriding a logger (appender) but in fact #tester already does it ... only a bit too late. So we need to find a better way of having samples rendered _and_ avoiding the call to `.render('output')` under tests. Any ideas?
