### PR TITLE
Adding packaged version when publishing to npm.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 build
-dist
 docs
 hashspace-gh-pages
 .idea

--- a/ci-release.sh
+++ b/ci-release.sh
@@ -1,3 +1,5 @@
+export HASHSPACE_VERSION=`node -e 'console.log(require("./package.json").version)'`
+echo "hashspace version: $HASHSPACE_VERSION"
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then
     # we need to clone the repo once again, as by default Travis CI makes
     # shallow clones where gh-pages branch is not available and can't be fetched
@@ -5,7 +7,8 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_SECURE_ENV_VARS" = "true" 
     git config user.email "releasebot@ariatemplates.com" &&
     git config user.name "Titan Bot" &&
     git checkout -b gh-pages origin/gh-pages &&
-    cp -rv ../dist . &&
+    mkdir -p "./dist/${HASHSPACE_VERSION}" &&
+    cp -rv ../dist/* "./dist/${HASHSPACE_VERSION}/" &&
     # web site publication is disabled for now:
     # grunt release &&
     # we add everything

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -243,7 +243,7 @@ module.exports = function (grunt) {
     },
     browserify: {
       runtime: {
-        files: [{dest: 'dist/'+pkg.version+'/hashspace-browserify.js', src: ['hsp/rt.js']}],
+        files: [{dest: 'dist/hashspace-browserify.js', src: ['hsp/rt.js']}],
         options: {
           aliasMappings: [
             {
@@ -265,7 +265,7 @@ module.exports = function (grunt) {
         }
       },
       compiler: {
-        files: [{dest: 'dist/'+pkg.version+'/hashspace-browserify-compiler.js', src: ['hsp/compiler/compiler.js']}],
+        files: [{dest: 'dist/hashspace-browserify-compiler.js', src: ['hsp/compiler/compiler.js']}],
         options: {
           aliasMappings: [
             {
@@ -280,10 +280,10 @@ module.exports = function (grunt) {
     uglify: {
       hsp: {
         files: [
-          {dest: 'dist/'+pkg.version+'/hashspace-browserify.min.js', src: ['dist/'+pkg.version+'/hashspace-browserify.js']},
-          {dest: 'dist/'+pkg.version+'/hashspace-browserify-compiler.min.js', src: ['dist/'+pkg.version+'/hashspace-browserify-compiler.js']},
-          {dest: 'dist/'+pkg.version+'/hashspace-noder.min.js', src: ['dist/'+pkg.version+'/hashspace-noder.js']},
-          {dest: 'dist/'+pkg.version+'/hashspace-noder-compiler.min.js', src: ['dist/'+pkg.version+'/hashspace-noder-compiler.js']}
+          {dest: 'dist/hashspace-browserify.min.js', src: ['dist/hashspace-browserify.js']},
+          {dest: 'dist/hashspace-browserify-compiler.min.js', src: ['dist/hashspace-browserify-compiler.js']},
+          {dest: 'dist/hashspace-noder.min.js', src: ['dist/hashspace-noder.js']},
+          {dest: 'dist/hashspace-noder-compiler.min.js', src: ['dist/hashspace-noder-compiler.js']}
         ]
       }
     },
@@ -300,7 +300,7 @@ module.exports = function (grunt) {
             options : {
                 sourceDirectories : ['.'],
                 sourceFiles : ['hsp/**/*.js'],
-                outputDirectory : 'dist/' + pkg.version,
+                outputDirectory : 'dist/',
                 visitors : [{
                             type : "ImportSourceFile",
                             cfg : {
@@ -361,11 +361,11 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('atpackager');
   require('atpackager').loadNpmPlugin('noder-js');
 
-  grunt.registerTask('prepublish', ['peg']);
-  grunt.registerTask('package', ['prepublish', 'browserify', 'atpackager:uglify','atpackager:runtime','uglify']);
+  grunt.registerTask('prepublish', ['package']);
+  grunt.registerTask('package', ['peg', 'browserify', 'atpackager:uglify','atpackager:runtime','uglify']);
   grunt.registerTask('mocha', ['peg', 'inittests', 'mochaTest', 'finalizetests']);
   grunt.registerTask('test', ['checkStyle', 'jscs', 'mocha', 'karma:unit']);
-  grunt.registerTask('ci', ['checkStyle', 'jscs', 'mocha', 'karma:ci1', 'karma:ci2', 'karma:coverage', 'package']);
+  grunt.registerTask('ci', ['checkStyle', 'jscs', 'mocha', 'karma:ci1', 'karma:ci2', 'karma:coverage']);
   grunt.registerTask('release', ['docs:release']);
   grunt.registerTask('default', ['docs:playground']);
 };


### PR DESCRIPTION
This pull request adds the `dist` folder to the npm package published on npm, and packaged files are now directly inside the `dist` folder instead of being in a folder with the version number inside the `dist` folder (removing 1 level of directories).
This makes it easier to use the packaged version of hashspace when depending on hashspace through npm.
