### PR TITLE
fix: properly create HTML5-specific input types on IE8 and 9

### DIFF
--- a/hsp/rt/eltnode.js
+++ b/hsp/rt/eltnode.js
@@ -107,7 +107,9 @@ var EltNode = klass({
      */
     createNode : function () {
         this.TYPE = this.tag; // for debugging purposes
-        var nd;
+        var nodeType = null, nodeName = null;
+        var nd, docFragment;
+
         if (this.tag === "svg") {
             if (browser.supportsSvg()) {
                 this.nodeNS = "http://www.w3.org/2000/svg";
@@ -115,12 +117,13 @@ var EltNode = klass({
                 log.error('This browser does not support SVG elements');
             }
         }
+
         if (this.nodeNS) {
             nd = doc.createElementNS(this.nodeNS, this.tag);
         } else {
             if (this.atts && this.atts.length > 0) {
-                var nodeType = null;
-                var nodeName = null;
+
+                nd = doc.createElement(this.tag);
                 for (var i = 0; i < this.atts.length; i++) {
                     if (this.atts[i].name === "type") {
                         nodeType = this.atts[i].value;
@@ -130,20 +133,19 @@ var EltNode = klass({
                     }
                 }
                 if (nodeType || nodeName) {
-                    // we have to use a special creation mode as IE doesn't support dynamic type and name change
                     try {
-                      nd = doc.createElement('<' + this.tag + (nodeType?' type=' + nodeType : '') + (nodeName?' name=' + nodeName : '') + ' >');
-                    } catch (ex) {
-                        nd = doc.createElement(this.tag);
                         if (nodeType) {
                             nd.type = nodeType;
                         }
                         if (nodeName) {
                             nd.name = nodeName;
                         }
+                    } catch (ex) {
+                        // we have to use a special creation mode as IE doesn't support dynamic type and name change
+                        docFragment = doc.createElement('div');
+                        docFragment.innerHTML = '<' + this.tag + (nodeType?' type=' + nodeType : '') + (nodeName?' name=' + nodeName : '') + ' >';
+                        nd = docFragment.children[0];
                     }
-                } else {
-                    nd = doc.createElement(this.tag);
                 }
             }
             else {

--- a/test/rt/input.spec.hsp
+++ b/test/rt/input.spec.hsp
@@ -50,6 +50,10 @@ var hsp=require("hsp/rt"),
     <input type="text" model="{object.value}" onkeydown="{object.keydown(event)}" placeholder="Your command"><br>
 # /template
 
+# template html5NumberInput(model)
+    <div><input type="number" model="{model.value}"/></div>
+# /template
+
 describe("Input Elements", function () {
     it("input model sync", function () {
         var v1 = "init value";
@@ -226,4 +230,7 @@ describe("Input Elements", function () {
         n.$dispose();
     });
 
+    it("should not fail on HTML5 input elements in browsers that dont support them", function() {
+        var n = html5NumberInput({value: 5});
+    });
 });


### PR DESCRIPTION
Another side effect of adding tests to samples: it turned out that IE8 and IE9 were failing if a HTML5 type was used on inputs. 

I'm not sure if this is a proper fix since it looks for me like the code in place couldn't have possibly worked from the beginning, so it is quite probable that I'm seriously misunderstanding things here....
