### PR TITLE
chore: don't report pull request build status to SauceLabs

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -203,7 +203,7 @@ module.exports = function (grunt) {
         browserNoActivityTimeout: 20000,
         captureTimeout: 300000,
         browsers: ['SL_Chrome', 'SL_Android_4.0', 'SL_Android_4.1', 'SL_IE_8', 'SL_IE_9', 'SL_Safari_7'],
-        reporters: ['dots', 'saucelabs']
+        reporters: process.env.TRAVIS_PULL_REQUEST ? ['dots'] : ['dots', 'saucelabs']
       },
       ci2: {
         sauceLabs: {
@@ -215,14 +215,14 @@ module.exports = function (grunt) {
         browserNoActivityTimeout: 20000,
         captureTimeout: 300000,
         browsers: ['SL_iOS_7', 'SL_Firefox', 'SL_Android_4.2', 'SL_Android_4.3', 'SL_IE_10', 'SL_IE_11', 'SL_Safari_6'],
-        reporters: ['dots', 'saucelabs']
+        reporters: process.env.TRAVIS_PULL_REQUEST ? ['dots'] : ['dots', 'saucelabs']
       },
       sauce: {
         singleRun: true,
         browserNoActivityTimeout: 20000,
         captureTimeout: 300000,
         browsers: ['SL_IE_8', 'SL_IE_9', 'SL_IE_10', 'SL_IE_11', 'SL_Safari_6', 'SL_Safari_7', 'SL_Firefox', 'SL_Chrome', 'SL_Android_4.0', 'SL_Android_4.1', 'SL_Android_4.2', 'SL_Android_4.3', 'SL_iOS_7'],
-        reporters: ['dots', 'saucelabs']
+        reporters: ['dots']
       }
     },
     jscs: {


### PR DESCRIPTION
As of today SauceLabs doesn't have any notion of git branches which means that any build - main branch or PR - will update "latest build" status. In practice it means that a failing PR build will make it look like the framework build is failing - a failed build status will be displayed on GitHub.

This PR changes the situation be reporting build status back to Sauce only on master branch builds. 
