### PR TITLE
chore: use Firefox to capture test coverage

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -167,15 +167,7 @@ module.exports = function (grunt) {
         //logLevel: 'LOG_INFO'
       },
       unit: {
-        singleRun: true,
-        preprocessors: {
-          'hsp/**/*.js': ['commonjs', 'coverage']
-        },
-        reporters: ['progress', 'coverage'],
-        coverageReporter: {
-          type : 'lcov',
-          dir : 'test-results/karma/'
-        }
+        singleRun: true
       },
       tdd: {
         singleRun: false,
@@ -187,7 +179,7 @@ module.exports = function (grunt) {
           'hsp/**/*.js': ['commonjs', 'coverage']
         },
         reporters: ['dots', 'coverage'],
-        browsers: ['PhantomJS'],
+        browsers: ['Firefox'],
         coverageReporter: {
           type : 'lcovonly',
           dir : 'test-results/karma/'

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "karma-firefox-launcher": "~0.1.3",
     "karma-sinon": "~1.0.2",
     "karma-coverage": "~0.1",
-    "karma-phantomjs-launcher": "~0.1",
     "karma-hsp-preprocessor": "~0.0.6",
     "blanket": "1.1.6",
     "mocha-lcov-reporter": "0.0.1",


### PR DESCRIPTION
TravisCI has Firefox installed so we can use it in order
to capture tests coverage. Using Firefox makes it possible to
avoid installing PhantomJS which speeds up the npm install about
10 to 20 %.

Additionally this PR removes test coverage from the default `test` task to speed up the build that we run very often.
