### PR TITLE
chore: restore compiler's coverage reporting

### DIFF
--- a/build/blanket.js
+++ b/build/blanket.js
@@ -1,11 +1,11 @@
-var path = require('path');
-var srcDir = path.join(__dirname, '..', 'hsp');
-
-require('blanket')({
-    // Only files that match the pattern will be instrumented
-    pattern: '//' + normalizeBackslashes(srcDir) + '(?!\/compiler\/parser\/hspblocks)/'
-});
-
 function normalizeBackslashes (str) {
     return str.replace(/\\/g, '/');
 }
+
+require('blanket')({
+    // Only files that match the pattern will be instrumented
+    pattern: function(fileName) {
+        fileName = normalizeBackslashes(fileName);
+        return fileName.indexOf('/hsp/compiler') >= 0 && fileName.indexOf('.peg.js') === -1;
+    }
+});

--- a/build/grunt/hspserver.js
+++ b/build/grunt/hspserver.js
@@ -1,12 +1,14 @@
 var express = require('express');
-var app = express();
-var server = require('http').createServer(app);
 var path = require("path");
 
-var renderer = require("../../hsp/compiler/renderer");
-
 module.exports = function(grunt) {
+
     grunt.registerTask('hspserver', 'Start a web server to server compiled templates on the fly', function () {
+
+        var renderer = require("../../hsp/compiler/renderer");
+        var app = express();
+        var server = require('http').createServer(app);
+
         grunt.config.requires('hspserver.port');
         grunt.config.requires('hspserver.base');
         grunt.config.requires('hspserver.templateExtension');


### PR DESCRIPTION
This commit restores proper reporting of compiler's test coverage that got broken via 71a467d7c67dcb909220db7a9b8bca3868119378. The culprit is this line: https://github.com/ariatemplates/hashspace/commit/71a467d7c67dcb909220db7a9b8bca3868119378#diff-74467b60c03e153dfefce7b39243fd95R6 which was causing node to load compiler's modules. This was preventing blanket.js from properly instrumenting code as it instruments things by "taking over" node's `require()` and processing code on the fly.
