### PR TITLE
fix: properly handle input type='button'

### DIFF
--- a/hsp/rt/eltnode.js
+++ b/hsp/rt/eltnode.js
@@ -300,7 +300,7 @@ var EltNode = klass({
 
                 } else if (nm === "value") {
                     // value attribute must be changed directly as the node attribute is only used for the default value
-                    if (!this.isInput || nd.type === "radio") {
+                    if (!this.isInput || nd.type === "radio" || nd.type === "button") {
                         nd.value = att.getValue(eh, vs, "");
                     }
                 } else {

--- a/test/rt/input.spec.hsp
+++ b/test/rt/input.spec.hsp
@@ -54,6 +54,10 @@ var hsp=require("hsp/rt"),
     <div><input type="number" model="{model.value}"/></div>
 # /template
 
+# template buttonInput()
+    <div><input type="button" value="I'm a button"><input type="button" value="{'I\'m a variable button'}"></div>
+# /template
+
 describe("Input Elements", function () {
     it("input model sync", function () {
         var v1 = "init value";
@@ -232,5 +236,11 @@ describe("Input Elements", function () {
 
     it("should not fail on HTML5 input elements in browsers that dont support them", function() {
         var n = html5NumberInput({value: 5});
+    });
+
+    it("should properly render inputs of type 'button'", function() {
+        var n = buttonInput();
+        expect(n.childNodes[0].childNodes[0].node.value).to.equal("I'm a button");
+        expect(n.childNodes[0].childNodes[1].node.value).to.equal("I'm a variable button");
     });
 });


### PR DESCRIPTION
This is first & fast attempt at fixing #193, but I wouldn't be surprised to see similar issues given the number of different input types (https://developer.mozilla.org/en/docs/Web/HTML/Element/Input). If I'm not mistaken we should have the same logic for submit buttons, at least. 

Anyway, opening a PR to see if tests pass on every browser and to kick off discussion on the design of inputs handling.
