### PR TITLE
Precompilation for the TodoMVC sample

### DIFF
--- a/build/grunt/hspserver.js
+++ b/build/grunt/hspserver.js
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
                 if (src) {
                     src=(''+src).replace(/\\u0026/gi,"&").replace(/\\u002B/gi,"+").replace(/\\u003F/gi,"?");
                     // compile src
-                    var r=renderer.renderString(src);
+                    var r=renderer.renderString(src, "<inline compilation>");
                     if (r.serverErrors && r.serverErrors.length) {
                         res.send(500,r.serverErrors[0].description);
                     } else {

--- a/docs/_css/site.less
+++ b/docs/_css/site.less
@@ -64,6 +64,13 @@ pre code, code {
   top: 30px;
 }
 
+hr {
+  border-width: 1px 0px 0px;
+  border-style: dotted none none;
+  border-color: #dedede #fff #fff;
+  height: 0px;
+}
+
 
 /* HOMEPAGE */
 .shadow() {
@@ -107,6 +114,9 @@ pre code, code {
         text-decoration: none;
       }
     }
+  }
+  hr {
+    margin: 25px 0px;
   }
 }
 
@@ -388,6 +398,10 @@ body.playground {
         margin: 0;
         padding-left: 30px;
       }
+    }
+    .errorlist {
+      background-color: orange;
+      padding: 5px 0px;
     }
   }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ And because Hashspace uses a virtual DOM for its computations, these updates are
 We believe in standards and best practices, so we built Hashspace with these in mind so that your code stays as much forward-compatible as possible.
 
 The engine is compatible with [CommonJS dependency management](http://noder-js.ariatemplates.com) principles and the upcoming object.observe() implementation.
-Hashspace components (have a look at the [playground](/playground/) also bring forward the much anticipated web components and make them available to every supported browser today.
+Hashspace components (have a look at the [playground](/playground/)) also bring forward the much anticipated web components and make them available to every supported browser today.
 
 
 ## Robust
@@ -66,7 +66,9 @@ The people behind Hashspace have years of experience in framework design and bui
 
 [CONTENT_END]
 
+---
 
+#### Code Samples
 
-
+To illustrate all these points, we crafted both a dynamic live [playground](/playground/) and an implementation of the [TodoMVC](/todomvc/) application using Hashspace. You can read more information about the todoMVC project [here](http://todomvc.com/).
 

--- a/docs/samples/todolist/description.md
+++ b/docs/samples/todolist/description.md
@@ -17,6 +17,6 @@ The compiled code can be viewed here: [samples/todolist/todolist.hsp][todolist.h
 
 [todolist.hsp]: /samples/todolist/todolist.hsp
 [react]: http://facebook.github.io/react/
-[todomvchsp]: /todomvc
+[todomvchsp]: /todomvc/
 [todomvc]: http://todomvc.com/
 [todomvcgh]: https://github.com/ariatemplates/hashspace/tree/master/docs/todomvc

--- a/docs/todomvc/index.html
+++ b/docs/todomvc/index.html
@@ -18,27 +18,14 @@
 
 <html>
 <head>
-  <script src="http://noder-js.ariatemplates.com/dist/v1.3.1/noder.dev.min.js">
+  <script src="http://noder-js.ariatemplates.com/dist/v1.3.1/noder.min.js">
     {
       packaging: {
-        baseUrl: "/",
-        preprocessors: [{
-          pattern: /\.hsp$/,
-          module: "hsp/compiler/compile"
-        }, {
-          pattern: /^(?!hsp\/|libs\/).*\.js$/,
-          module: "hsp/transpiler/transpile"
-        }]
-      },
-      resolver: {
-        "default" : {
-          "uglify-js" : "/libs/uglify-js"
-        }
+        baseUrl: "/"
       }
     }
   </script>
   <script src="/dist/<%=version%>/hashspace-noder.min.js" type="text/javascript"></script>
-  <script src="/dist/<%=version%>/hashspace-noder-compiler.min.js" type="text/javascript"></script>
   <link href="todo.css" type="text/css" rel="stylesheet"/>
 </head>
 <body>
@@ -46,7 +33,7 @@
 <div id="todo"></div>
 
 <script type="noder">
-  var todos = require("/todomvc/todo.hsp").todos;
+  var todos = require("/todomvc/todo.hsp.js").todos;
   todos().render("todo");
 </script>
 


### PR DESCRIPTION
This pull request introduces precompilation for the todomvc sample.
Both hsp and js file are compiled, transpiled and minified.

The grunt build has been updated to introduce few new tasks
- `docs:todo-package` that is shorcut to execute these 2 others sub-tasks
  - `docs:todo-compile`
  - `uglify:todomvc`
