### PR TITLE
fix apiref CSS: overflowing text

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,7 +1,7 @@
 title: API Reference
 cssclass: api
 mappings:
-  CONTENT_BEGIN: <article class="columns"><div class="column">
+  CONTENT_BEGIN: <article class="columns"><div>
   CONTENT_END: </div></article>
   WIP: <div id="wip">Work in progress</div>
 ---


### PR DESCRIPTION
In Firefox, when zoomed, some text overflows inside a floated container and is clipped (this also happens in Firefox when the font of code is changed).

![apiref-firefox](https://cloud.githubusercontent.com/assets/1437027/3286593/c1d04e80-f54b-11e3-81bc-fad644c987b9.png)

This commit removes the floating, since for a single child element it doesn't make sense anyway to be floated.

---

I didn't change the CSS of `column` since it seems to be taken from AT.com directly, and it works fine on AT.com, but there the layout is different, it has a column and a sidebar.
