### PR TITLE
fix #180 IE8: HTML test runner fails to load

### DIFF
--- a/build/grunt/docs.js
+++ b/build/grunt/docs.js
@@ -196,14 +196,20 @@ module.exports = function(grunt) {
   });
 
   function compileHashspace(req, res, suffix) {
-    var renderer  = require("../../hsp/compiler/renderer");
-    var content = fs.readFileSync(suffix + req.url, "utf8");
-    var r = renderer.renderString(content, req.url.substring(req.url.lastIndexOf("/") + 1));
-    if (r.serverErrors && r.serverErrors.length) {
-        res.send(500, r.serverErrors[0].description);
-    } else {
-        res.send(200, r.code);
-    }
+      fs.readFile(suffix + req.url, "utf8", function (err, content) {
+          if (err) {
+              res.send(500, err.message);
+          }
+          else {
+              var renderer  = require("../../hsp/compiler/renderer");
+              var r = renderer.renderString(content, req.url.substring(req.url.lastIndexOf("/") + 1));
+              if (r.serverErrors && r.serverErrors.length) {
+                  res.send(500, r.serverErrors[0].description);
+              } else {
+                  res.send(200, r.code);
+              }
+          }
+      });
   }
 
   // Playground Express Server


### PR DESCRIPTION
HTML test runner back on track with server side compilation.
