### PR TITLE
Added /* */ multiline comments

### DIFF
--- a/hsp/compiler/parser/hspblocks.pegjs
+++ b/hsp/compiler/parser/hspblocks.pegjs
@@ -64,7 +64,7 @@ TemplateEnd "template end statement"
 
 TemplateContent "template content" // TODO: CSSClassExpression
   = _ blocks:(  TplTextBlock 
-                / CommentBlock / HTMLCommentBlock
+                / CommentBlock / MultiCommentBlock / HTMLCommentBlock
                 / IfBlock / ElseIfBlock / ElseBlock / EndIfBlock 
                 / ForeachBlock / EndForeachBlock
                 / HTMLElement / EndHTMLElement
@@ -88,7 +88,7 @@ TplTextChar "text character"
   / EOL &TemplateEnd {return ""}  // ignore last EOL
   / EOL _ {return " "}
   / "#" !(_ "\/template") {return "#"}
-  / "\/" !"/" {return "/"}
+  / "\/" c:[^/\*] {return "/"+c}
   / "\\/" {return "/"}
   / "\\//" {return "//"}
   / "\\<" {return "<"}
@@ -116,6 +116,10 @@ EndIfBlock
 
 CommentBlock
   = _ "\/\/" chars:[^\r\n]* &EOL
+  {return {type:"comment", value:chars.join('')}}
+
+MultiCommentBlock
+  = "/*" chars:((!"*/" c:.) {return c})* "*/"
   {return {type:"comment", value:chars.join('')}}
 
 HTMLCommentBlock

--- a/test/compiler/samples/comment.txt
+++ b/test/compiler/samples/comment.txt
@@ -1,14 +1,16 @@
 ##### Template:
 # template hello(world)
-	Hello // comment 1
-	World!
+	Hel / lo // comment 1
+	World! /* this is a
+	multi line
+	comment */
 	{if (world)} // comment 2
 	   <!-- another comment
 	   on multiple 
 	   lines 
 	   # /template
 	   -->
-	   ...
+	   ... Escaping \/* works *\/
 	{/if}
 # /template
 
@@ -20,15 +22,17 @@
     "name": "hello",
     "args": ["world"],
     "content": [
-      {"type": "text","value": "Hello "},
+      {"type": "text","value": "Hel / lo "},
       {"type": "comment","value": " comment 1"},
       {"type": "text","value": " World! "},
+      {"type": "comment","value": " this is a\n\tmulti line\n\tcomment "},
+      {"type": "text","value": " "},
       {"type": "if", "condition": {type:"Variable", category:"jsexpression", name:"world"}},
       {"type": "text","value": " "},
       {"type": "comment","value": " comment 2"},
       {"type": "text","value": " "},
       {"type": "comment","value": " another comment\n\t   on multiple \n\t   lines \n\t   # /template\n\t   "},
-      {"type": "text","value": " ... "},
+      {"type": "text","value": " ... Escaping /* works */ "},
       {"type": "endif"}
     ]
   }
@@ -43,7 +47,7 @@
     "content": [
       {
         "type": "text",
-        "value": "Hello  World! "
+        "value": "Hel / lo  World!  "
       },
       {
         "type": "if",
@@ -54,13 +58,13 @@
           "path": [
             "world"
           ],
-          "line": 4,
+          "line": 6,
           "column": 6
         },
         "content1": [
           {
             "type": "text",
-            "value": "   ... "
+            "value": "   ... Escaping /* works */ "
           }
         ]
       }
@@ -70,8 +74,8 @@
 
 ##### Template Code
 hello=[
-  n.$text(0,["Hello  World!"]),
+  n.$text(0,["Hel / lo  World!"]),
   n.$if( {e1:[1,1,"world"]}, 1, [ 
-      n.$text(0,["   ... "])
+      n.$text(0,["   ... Escaping /* works */ "])
   ])
 ]


### PR DESCRIPTION
Simple grammar update to allow for /\* */ multiline comments.

On top of this change I'd challenge the need to keep the value property of comment nodes is the parsed tree since we don't do anything with it afterwards (this would make the rules a tad simpler.) @b-laporte what do you think?
