### PR TITLE
chore: print out sauce connect logs only after failrue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ after_success:
  - chmod -R 777 ./ci-release.sh
  - ./ci-release.sh
 
-after_script:
+after_failure:
   - chmod -R 777 ./build/sauce/connect_logs.sh
   - ./build/sauce/connect_logs.sh


### PR DESCRIPTION
Tiny PR to only print out souce labs logs if things go bad and avoid spamming TravisCI output when things are in order.
