### PR TITLE
docs: getting started

### DIFF
--- a/docs/_css/site.less
+++ b/docs/_css/site.less
@@ -121,12 +121,23 @@ hr {
   }
 }
 
-/* API */
+/* GETTING STARTED */
 
-.api {
-  nav a.api {
+.getting-started {
+  nav a.link-getting-started {
     .navselected();
   }
+}
+
+/* API */
+.api {
+  nav a.link-api {
+    .navselected();
+  }
+}
+
+/* API and GETTING-STARED shared */
+.api-shared {
   .content-wrapper {
     section.content {
       background: #fff;
@@ -170,7 +181,7 @@ body.playground {
   top: 0px; left: 0px;
   width: 100%; height: 100%;
 
-  nav a.playground {
+  nav a.link-playground {
     .navselected();
   }
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -30,9 +30,9 @@
         </a></h1>
       </div>
       <nav>
-        <a href="/start/">Getting started</a>
-        <a class="api" href="/api/">API</a>
-        <a class="playground" href="/playground/">Playground</a>
+        <a class="link-getting-started" href="/start/">Getting started</a>
+        <a class="link-api" href="/api/">API</a>
+        <a class="link-playground" href="/playground/">Playground</a>
         <a href="http://github.com/ariatemplates/hashspace">Github</a>
         <a class="download button green" target="_blank" href="https://github.com/ariatemplates/hashspace/releases">Download</a>
       </nav>

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,5 @@
 title: API Reference
-cssclass: api
+cssclass: api-shared api
 mappings:
   CONTENT_BEGIN: <article class="columns"><div>
   CONTENT_END: </div></article>

--- a/docs/start/explained/index.md
+++ b/docs/start/explained/index.md
@@ -1,5 +1,5 @@
 title: Getting started
-cssclass: api
+cssclass: api-shared getting-started
 mappings:
   CONTENT_BEGIN: <article class="columns"><div>
   CONTENT_END: </div></article>

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -1,5 +1,5 @@
 title: Getting started
-cssclass: api
+cssclass: api-shared getting-started
 mappings:
   CONTENT_BEGIN: <article class="columns"><div>
   CONTENT_END: </div></article>
@@ -70,12 +70,12 @@ To run your Hashspace application, you have two options:
   - have a dedicated build & deploy script, or
   - configure a file watcher which runs the compilation whenever some `.hsp` or `.js` file changes on disk
 
+## On-the-fly (in-browser) compilation
+
 **Note that applications using in-browser compilation will be significantly less performant
 than the ones using precompiled templates. Use the in-browser compilation only to get
 started and for rapid prototyping.
 Once you're familiar with Hashspace, you should switch to the precompilation workflow.**
-
-## On-the-fly (in-browser) compilation
 
 We need to include the following in the page:
 


### PR DESCRIPTION
This also adds horizontal scrollbar to `<code>` if necessary

For review:
- `grunt`,
- goto `localhost:8000/start`

I largely used one of David's plunks and Paweł's repo https://github.com/PK1A/hsp-hello-gulp  for code samples.

In the example I had to resort to `klass` and `attributes` so that I can really have a parameter in template that is actually passed further to the controller. 

Paweł's sample is much simpler though the parameter passed in [1] is actually discarded and the init value has to be hardcoded in [2].

[1] https://github.com/PK1A/hsp-hello-gulp/blob/master/src/index.html#L8
[2] https://github.com/PK1A/hsp-hello-gulp/blob/master/src/hello.js#L2
