### PR TITLE
orderBy and Sorter to manage list sorting

### DIFF
--- a/docs/samples/listsorting/description.md
+++ b/docs/samples/listsorting/description.md
@@ -1,0 +1,25 @@
+
+This example shows how lists can be ordered:
+
+[#output]
+
+Hashspace actually proposes two built-in methods to manage sorting:
+
+ - for simple cases, sorting can be handled with the **orderBy** method that accepts 2 arguments:
+   - first an expression describing the type of sort should be performed. This expression can be either a string that should correspond to an item property name, or a function that will be used to sort. The signature of the sort function should be the same as the [Array.sort()][sort] argument.
+   - second a boolean telling if the sort ordered should be reversed (default: false) 
+ - for advanced cases, sorting can be done with a **Sorter** instance that can handle a sort state, and proposes simple methods to dynamically change the sorting state. The Sorter constructor accepts the following *options* through a configuration object:
+   - **property**: a property name corresponding to the item property to sort
+   - **sortFunction**: a function to use to sort the collection passed to apply()
+     Note: either property or sortfunction must be provided - they will be internally passed as expression 
+     to the orderBy() function. If both are provided sortFunction is used and property is ignored.
+   - **states**: a string representing the possible sorting states. This string must be composed of the following letters:
+**"A"** for ascending sort, **"D"** for descending sort and **"N"** for no sort (i.e. keep original order). As such using "NAD" (default) means that first sort order will be None, then Ascending, then Descending. Then the sort order can be changed through the nextState() or setState() methods 
+
+
+*Note 1:* orderBy and Sorter are defined in the hashspace global collection and are available in all templates.
+
+*Note 2:* Sorter exposes an apply() method that is automatically called when used in a pipe expression - this is why it doesn't need to be explicitely called in the sample template.
+
+
+[sort]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

--- a/docs/samples/listsorting/list.hsp
+++ b/docs/samples/listsorting/list.hsp
@@ -1,0 +1,39 @@
+{template list(persons)}
+    <div onselectstart="return false"> 
+        <div class="msg">
+            <span class="info">
+                List sorted with the orderBy() function:
+            </span>
+            <ol>
+                {foreach p in persons|orderBy:"name"}
+                    <li>{p.name}</li>
+                {/foreach}
+            </ol>
+        </div>
+        <hr/>
+        <div class="msg">
+            {let nameSorter=new Sorter({property:"name",states:"ADN"})}
+            <span class="info">
+                List sorted with a Sorter object (current state: {nameSorter.state})
+            </span>
+            <ol>
+                {foreach p in persons|nameSorter}
+                    <li>{p.name}</li>
+                {/foreach}
+            </ol>
+            <a onclick="{nameSorter.nextState()}">Change sort order</a>
+        </div>
+    </div>
+{/template}
+
+var people = [
+    {name:"Homer", age:38},
+    {name:"Marge", age:38},
+    {name:"Bart", age:10},
+    {name:"Lisa", age:8},
+    {name:"Maggie", age:1}
+];
+
+// display the template in the #output div
+list(people).render("output");
+

--- a/docs/samples/samples.js
+++ b/docs/samples/samples.js
@@ -45,6 +45,13 @@ module.exports = [{
                         main : true
                     }]
         }, {
+            title : "List ordering: orderBy and Sorter",
+            folder : "listsorting",
+            files : [{
+                        src : "list.hsp",
+                        main : true
+                    }]
+        }, {
             title : "Dynamic data path: simple grid",
             folder : "dynpath",
             files : [{

--- a/hsp/rt.js
+++ b/hsp/rt.js
@@ -22,7 +22,8 @@ var klass = require("./klass"),
     $RootNode = $root.$RootNode,
     $CptNode = $root.$CptNode,
     $CptAttElement = $root.$CptAttElement,
-    cptwrapper = require("./rt/cptwrapper");
+    cptwrapper = require("./rt/cptwrapper"),
+    colutils = require("./rt/colutils");
 
 
 var NodeGenerator = klass({
@@ -91,6 +92,7 @@ var refreshTimeout = function () {
 };
 
 var global=exports.global={};
+colutils.setGlobal(global);
 
 /**
  * Return the global reference corresponding to a given name

--- a/hsp/rt/colutils.js
+++ b/hsp/rt/colutils.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ /**
+  * This files gathers a list of utilities that are useful to sort,
+  * filter or paginate collections in hashspace
+  * These utils are published in hsp.global
+  */
+
+var log = require("./log"),
+    klass = require("../klass"),
+    $set = require("../$set");
+
+/**
+ * This function returns a sorted copy of an array.
+ * It is typically meant to be used as a pipe modifier in a {foreach} statement
+ * @param {Array} array the original array
+ * @param {Function|String} expression the expression indicating how the sort should be performed
+ *   it can be of 2 types:
+ *     - a function that will be used as Array.sort() argument - so it needs to return something that
+ *       can be compared with the >, < or == operators
+ *     - a string representing an item property that will be used to sort (e.g. "name")
+ * @param {Boolean} reverse if true the order will be reversed (default: false)
+ */
+var orderBy = exports.orderBy = function (array, expression, reverse) {
+    var arr, sortFn, sortProp=null, reverse=(reverse===true);
+    if (array.constructor!==Array) {
+        log.error("[orderBy()] array argument must be of type Array");
+        return [];
+    }
+    // clone array
+    arr = array.slice(0);
+
+    if (expression.constructor===Function) {
+        sortFn=expression;
+    } else if (expression.constructor===String && expression!=='') {
+        sortProp=expression;
+    } else {
+        log.error("[orderBy()] Invalid expression argument: "+expression);
+        return arr;
+    }
+    // create sortFn if sortProp is used
+    if (sortProp) {
+        sortFn=function(a,b) {
+            var v1=a[sortProp], v2=b[sortProp];
+            v1 = v1? v1 : "";
+            v2 = v2? v2 : "";
+            if (v1>v2) {
+                return 1;
+            } else {
+                return v1==v2? 0 : -1;
+            }
+        };
+    }
+    // adapt sortFn if reverse
+    var sfn=sortFn;
+    if (reverse) {
+        sfn=function(a,b) {
+            return sortFn(a,b) * -1;
+        };
+    }
+    return arr.sort(sfn);
+};
+
+/**
+ * Sort processors that can keep sorting state (e.g. ascending, descending or none)
+ * and that exposes simple method to be used in pipe expressions
+ */
+var Sorter = exports.Sorter = klass({
+    /**
+     * Sorter constructor
+     * @param {Object} options a JSON object with the following properties:
+     *   - {String} sortProperty: a property name corresponding to the item property to sort on through the apply() method
+     *   - {Function} sortFunction: a function to use to sort the collection passed to apply()
+     *        Note: either property or sortfunction must be provided - they will be internally passed as expression 
+     *        to the orderBy() function. If both are provided sortFunction is used and property is ignored.
+     *   - {String} states: a string representing the possible sorting states. This string must be composed 
+     *        of the following letters:
+     *           - "A" for ascending sort
+     *           - "D" for descending sort
+     *           - "N" for no sort (i.e. keep original order)
+     *        As such using "NAD" (default) means that first sort order will be None, then Ascending, then Descending
+     *        The sort order can be changed through the nextState() or setState() methods 
+     */
+    $constructor:function(options) {
+        var sfn=this.sortFunction=options.sortFunction;
+        var pp=this.sortProperty=options.property;
+        this.state="N"; // default state in case of error
+        this.states=["N"];
+
+        // validate options
+        if (sfn) {
+            if (sfn.constructor!==Function) {
+                return log.error("[Sorter] Sort function must be a function: "+sfn);
+            }
+        } else if (pp) {
+            if (pp.constructor!==String) {
+                return log.error("[Sorter] Sort property must be a string: "+pp);
+            }
+        }
+
+        var ost=options.states, states=[], ch;
+        if (ost && ost.constructor!==String) {
+            log.error("[Sorter] states option must be a string: "+ost);
+            ost="NAD";
+        } else {
+            ost= ost? ost.toUpperCase() : "NAD"; // NAD is the default states value
+        }
+        for (var i=0;ost.length>i;i++) {
+            ch=ost.charAt(i);
+            if (!ch.match(/[NAD]/)) {
+                log.error("[Sorter] Invalid state code: "+ch);
+            } else {
+                states.push(ch);
+            }
+        }
+        this.state=states[0];
+        this.states=states;
+    },
+    /**
+     * Apply the sort on a given array
+     * @param {Array} array the array to sort
+     * @return {Array} a sorted copy of the array
+     */
+    apply:function(array) {
+        if (array.constructor!==Array) {
+            log.error("[Sorter.apply()] array argument must be of type Array");
+            return [];
+        }
+        if (this.state==="N") {
+            return array.slice(0); // clone
+        } else {
+            var reverse=(this.state==="D"), expr=this.sortFunction? this.sortFunction : this.sortProperty;
+            return orderBy(array,expr,reverse);
+        }
+    },
+
+    /**
+     * Moves the state to the next possible value, according to the states options (e.g. "NAD")
+     */
+    nextState:function() {
+        var states=this.states, next=states[0], st=this.state;
+        for (var i=0;states.length-1>i;i++) {
+            if (states[i]===st) {
+                next=states[i+1];
+                break;
+            }
+        }
+        $set(this,"state",next);
+    },
+
+    /**
+     * Set the sorter state to a given state - that must be defined in the states options (e.g. "D" in "ADN")
+     */
+    setState:function(state) {
+        // check that state is valid (must iterate as indexOf() in part of ES5)
+        var found=false, states=this.states;
+        for (var i=0;states.length>i;i++) {
+            if (states[i]===state) {
+                found=true;
+                break;
+            }
+        }
+        if (!found) {
+            log.error("[Sorter.setState] state argument '"+state+"' is not part of the possible states '"+this.states.join('')+"'");
+        } else {
+            $set(this,"state",state);
+        }
+    }
+});
+
+/*
+ * Register all module exports to the hashspace global object
+ * @param {Object} global the hashspace global object
+ */
+exports.setGlobal = function(global) {
+    global.orderBy=orderBy;
+    global.Sorter=Sorter;
+};

--- a/test/rt/colutils.spec.js
+++ b/test/rt/colutils.spec.js
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var hsp = require("hsp/rt"),
+    ht=require("hsp/utils/hashtester");
+
+var orderBy = hsp.global.orderBy,
+    Sorter = hsp.global.Sorter;
+
+describe("Collection utils", function () {
+
+    var h, people = [
+        {name:"Homer", age:38},
+        {name:"Marge", age:38},
+        {name:"Bart", age:10},
+        {name:"Lisa", age:8},
+        {name:"Maggie", age:1}
+    ];
+
+    var ageSort=function(a,b) {
+        var v1=a.age, v2=b.age;
+        if (v1>v2) {
+            return 1;
+        } else {
+            return v1==v2? 0 : -1;
+        }
+    };
+
+    beforeEach(function () {
+         h=ht.newTestContext();
+     });
+
+    afterEach(function () {
+        h.$dispose();
+    });
+
+    it("should log an error when wrong array type is passed to orderBy()", function () {
+        var r=orderBy({"0":"A","1":"B"},"name");
+
+        expect(r.length).to.equal(0);
+        expect(r).not.to.equal(people);
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("[orderBy()] array argument must be of type Array");
+        h.logs.clear();
+    });
+
+    it("should log an error when wrong expression is passed to orderBy()", function () {
+        var r=orderBy(people,123);
+
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("[orderBy()] Invalid expression argument: 123");
+        h.logs.clear();
+    });
+
+    it("validates orderBy() with property expression", function () {
+        var r=orderBy(people,"name");
+
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[0].name).to.equal("Bart");
+        expect(r[1].name).to.equal("Homer");
+        expect(r[2].name).to.equal("Lisa");
+        expect(r[3].name).to.equal("Maggie");
+        expect(r[4].name).to.equal("Marge");
+    });
+
+    it("validates orderBy() with property expression + reverse order", function () {
+        var r=orderBy(people,"name",true);
+
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[4].name).to.equal("Bart");
+        expect(r[3].name).to.equal("Homer");
+        expect(r[2].name).to.equal("Lisa");
+        expect(r[1].name).to.equal("Maggie");
+        expect(r[0].name).to.equal("Marge");
+    });
+
+    it("validates orderBy() with property expression and missing properties", function () {
+        var p=people.slice(0); // clone
+        p[1]={firsName:"Marge"}; // no name
+        var r=orderBy(p,"name");
+
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[0].firsName).to.equal("Marge");
+        expect(r[1].name).to.equal("Bart");
+        expect(r[2].name).to.equal("Homer");
+        expect(r[3].name).to.equal("Lisa");
+        expect(r[4].name).to.equal("Maggie");
+    });
+
+    it("validates orderBy() with function expression", function () {
+        var r=orderBy(people,ageSort);
+
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[0].name).to.equal("Maggie");
+        expect(r[1].name).to.equal("Lisa");
+        expect(r[2].name).to.equal("Bart");
+        expect(r[3].name).to.equal("Homer");
+        expect(r[4].name).to.equal("Marge");
+    });
+
+    it("validates orderBy() with function expression + reverse order", function () {
+        var r=orderBy(people,ageSort,true);
+
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[4].name).to.equal("Maggie");
+        expect(r[3].name).to.equal("Lisa");
+        expect(r[2].name).to.equal("Bart");
+        expect(r[0].name).to.equal("Homer"); // first in original array and similar age to Marge
+        expect(r[1].name).to.equal("Marge");
+    });
+
+    it("should log an error when Sorter constructor is called with an invalid sort function option", function () {
+        var sorter=new Sorter({sortFunction:"foo",states:"AD"});
+
+        expect(sorter.state).to.equal("N");
+        expect(sorter.states.join('')).to.equal("N");
+        
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("[Sorter] Sort function must be a function: foo");
+        h.logs.clear();
+    });
+
+    it("should log an error when Sorter constructor is called with an invalid sort property option", function () {
+        var sorter=new Sorter({property:123,states:"AD"});
+
+        expect(sorter.state).to.equal("N");
+        expect(sorter.states.join('')).to.equal("N");
+        
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("[Sorter] Sort property must be a string: 123");
+        h.logs.clear();
+    });
+
+    it("should log an error when Sorter constructor is called with an invalid states option type", function () {
+        var sorter=new Sorter({property:"name",states:123});
+
+        expect(sorter.state).to.equal("N");
+        expect(sorter.states.join('')).to.equal("NAD");
+        
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("[Sorter] states option must be a string: 123");
+        h.logs.clear();
+    });
+
+    it("should log an error when Sorter constructor is called with an invalid states option value", function () {
+        var sorter=new Sorter({property:"name",states:"AXN"});
+
+        expect(sorter.state).to.equal("A");
+        expect(sorter.states.join('')).to.equal("AN");
+        
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("[Sorter] Invalid state code: X");
+        h.logs.clear();
+    });
+
+    it("validates Sorter with sort property and default states", function () {
+        var sorter=new Sorter({property:"name"});
+
+        expect(sorter.state).to.equal("N");
+
+        var r=sorter.apply(people);
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[0].name).to.equal("Homer");
+        expect(r[1].name).to.equal("Marge");
+        expect(r[2].name).to.equal("Bart");
+        expect(r[3].name).to.equal("Lisa");
+        expect(r[4].name).to.equal("Maggie");
+
+        // change state
+        sorter.nextState();
+        expect(sorter.state).to.equal("A");
+        r=sorter.apply(people);
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[0].name).to.equal("Bart");
+        expect(r[1].name).to.equal("Homer");
+        expect(r[2].name).to.equal("Lisa");
+        expect(r[3].name).to.equal("Maggie");
+        expect(r[4].name).to.equal("Marge");
+
+        // change state
+        sorter.nextState();
+        expect(sorter.state).to.equal("D");
+        r=sorter.apply(people);
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[4].name).to.equal("Bart");
+        expect(r[3].name).to.equal("Homer");
+        expect(r[2].name).to.equal("Lisa");
+        expect(r[1].name).to.equal("Maggie");
+        expect(r[0].name).to.equal("Marge");
+
+        // change state
+        sorter.nextState();
+        expect(sorter.state).to.equal("N");
+    });
+
+    it("validates Sorter with sort function and AD states", function () {
+        var sorter=new Sorter({property:"name",sortFunction:ageSort,states:"AD"}); // property will be ignored
+
+        expect(sorter.state).to.equal("A");
+
+        var r=sorter.apply(people);
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[0].name).to.equal("Maggie");
+        expect(r[1].name).to.equal("Lisa");
+        expect(r[2].name).to.equal("Bart");
+        expect(r[3].name).to.equal("Homer");
+        expect(r[4].name).to.equal("Marge");
+
+        // change state
+        sorter.nextState();
+        expect(sorter.state).to.equal("D");
+        r=sorter.apply(people);
+        expect(r[4].name).to.equal("Maggie");
+        expect(r[3].name).to.equal("Lisa");
+        expect(r[2].name).to.equal("Bart");
+        expect(r[0].name).to.equal("Homer"); // first in original array and similar age to Marge
+        expect(r[1].name).to.equal("Marge");
+
+        // change state
+        sorter.nextState();
+        expect(sorter.state).to.equal("A");
+    });
+
+    it("validates Sorter.setState()", function () {
+        var sorter=new Sorter({property:"name"});
+
+        sorter.setState("A");
+        expect(sorter.state).to.equal("A");
+        var r=sorter.apply(people);
+        expect(r.length).to.equal(5);
+        expect(r).not.to.equal(people);
+        expect(r[0].name).to.equal("Bart");
+        expect(r[1].name).to.equal("Homer");
+        expect(r[2].name).to.equal("Lisa");
+        expect(r[3].name).to.equal("Maggie");
+        expect(r[4].name).to.equal("Marge");
+    });
+
+    it("should log an error when Sorter.setState() is called with an invalid argument", function () {
+        var sorter=new Sorter({property:"name",states:"AD"});
+
+        sorter.setState("N");
+        expect(sorter.state).to.equal("A");
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("[Sorter.setState] state argument 'N' is not part of the possible states 'AD'");
+        h.logs.clear();
+    });
+
+    it("should log an error when Sorter.apply() is called with an invalid argument", function () {
+        var sorter=new Sorter({property:"name",states:"AD"});
+
+        var r=sorter.apply(123);
+        expect(r.length).to.equal(0);
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("[Sorter.apply()] array argument must be of type Array");
+        h.logs.clear();
+    });
+
+});

--- a/test/rt/index.html
+++ b/test/rt/index.html
@@ -48,6 +48,7 @@
 	// runtime tests
 	require("test/rt/$set.spec.js");
 	require("test/rt/global.spec.hsp");
+	require("test/rt/colutils.spec.js");
 	require("test/rt/booleanAttributes.spec.hsp");
 	require("test/rt/cptattelements1.spec.hsp");
 	require("test/rt/cptattelements2.spec.hsp");


### PR DESCRIPTION
This PR introduces two new utilities to manage list ordering: orderBy and Sorter. As you will see orderBy is very convenient for simple cases, whereas Sorter (that internally uses orderBy) provides more advanced features:

```
{template list(persons)}
    <div onselectstart="return false"> 
        <div class="msg">
            <span class="info">
                List sorted with the orderBy() function:
            </span>
            <ol>
                {foreach p in persons|orderBy:"name"}
                    <li>{p.name}</li>
                {/foreach}
            </ol>
        </div>
        <hr/>
        <div class="msg">
            {let nameSorter=new Sorter({property:"name",states:"ADN"})}
            <span class="info">
                List sorted with a Sorter object (current state: {nameSorter.state})
            </span>
            <ol>
                {foreach p in persons|nameSorter}
                    <li>{p.name}</li>
                {/foreach}
            </ol>
            <a onclick="{nameSorter.nextState()}">Change sort order</a>
        </div>
    </div>
{/template}

var people = [
    {name:"Homer", age:38},
    {name:"Marge", age:38},
    {name:"Bart", age:10},
    {name:"Lisa", age:8},
    {name:"Maggie", age:1}
];

// display the template in the #output div
list(people).render("output");
```

Both features are published on hsp.global, so they don't need to be required and are available everywhere.
