### PR TITLE
add possibility to dynamically change component type - fix #233

### DIFF
--- a/hsp/rt/cptattinsert.js
+++ b/hsp/rt/cptattinsert.js
@@ -40,9 +40,11 @@ module.exports.$CptAttInsert = {
 
   /**
    * Safely cut all dependencies before object is deleted
+   * @param {Boolean} localPropOnly if true only local properties will be deleted (optional)
+   *        must be used when a new instance is created to adapt to a path change
    */
-  $dispose:function() {
+  $dispose:function(localPropOnly) {
     this.cptAllElt=null;
-    this.cleanObjectProperties();
+    this.cleanObjectProperties(localPropOnly);
   }
 };

--- a/hsp/rt/cptcomponent.js
+++ b/hsp/rt/cptcomponent.js
@@ -35,15 +35,9 @@ exports.$CptComponent = {
 
     if (this.template) {
       // this component is associated to a template
-      var needCommentNodes=(this.createPathObservers() || this.ctlConstuctor.$refresh);
-
-      if (needCommentNodes) {
-        this.createCommentBoundaries("cpt");
-        this.createChildNodeInstances();
-      } else {
-        // WARNING: this changes the original vscope to the template vscope
-        this.template.call(this, this.getTemplateArguments(), this.getCptArguments());
-      }
+      this.createPathObservers();
+      this.createCommentBoundaries("cpt");
+      this.createChildNodeInstances();
 
       // $init child components
       this.initChildComponents();
@@ -120,10 +114,7 @@ exports.$CptComponent = {
    * that node1 and node2 exist
    */
   createChildNodeInstances : function () {
-      if (!this.isDOMempty) {
-          this.removeChildNodeInstances(this.node1,this.node2);
-          this.isDOMempty = true;
-      }
+      this.removeChildInstances();
 
       if (this.template) {
         // temporarily assign a new node to get the content in a doc fragment
@@ -143,15 +134,17 @@ exports.$CptComponent = {
 
   /**
    * Safely cut all dependencies before object is deleted
+   * @param {Boolean} localPropOnly if true only local properties will be deleted (optional)
+   *        must be used when a new instance is created to adapt to a path change
    */
-  $dispose:function() {
+  $dispose:function(localPropOnly) {
     if (this.ctlWrapper) {
       this.ctlWrapper.$dispose();
       this.ctlWrapper=null;
       this.controller=null;
     }
     this.ctlAttributes=null;
-    this.cleanObjectProperties();
+    this.cleanObjectProperties(localPropOnly);
     this.ctlConstuctor=null;
     var tpa=this.tplAttributes;
     if (tpa) {
@@ -453,9 +446,13 @@ exports.$CptComponent = {
 
           this.edirty=false;
       }
+      // warning: the following refresh may change the component type and
+      // as such ctlWrapper could become null if new component is a template
       $CptNode.refresh.call(this);
-      // refresh cpt through $refresh if need be
-      this.ctlWrapper.refresh();
+      if (this.ctlWrapper) {
+        // refresh cpt through $refresh if need be
+        this.ctlWrapper.refresh();
+      }
   },
 
   /**

--- a/hsp/rt/cpttemplate.js
+++ b/hsp/rt/cpttemplate.js
@@ -14,15 +14,10 @@ module.exports.$CptTemplate = {
    *     e.g. {template:obj,ctlConstuctor:obj.controllerConstructor}
    */
   initCpt:function(arg) {
-    // determine if template path can change dynamically
-    var isDynamicTpl=this.createPathObservers();
-
-    if (isDynamicTpl) {
-      this.createCommentBoundaries("template");
-      this.createChildNodeInstances();
-    } else {
-      arg.template.call(this, this.getTemplateArguments());
-    }
+    // create path observers and comment boundaries
+    this.createPathObservers();
+    this.createCommentBoundaries("template");
+    this.createChildNodeInstances();
 
     // the component is a template without any controller
     // so we have to observe the template root scope to be able to propagate changes to the parent scope
@@ -35,10 +30,7 @@ module.exports.$CptTemplate = {
    * that node1 and node2 exist
    */
   createChildNodeInstances : function () {
-      if (!this.isDOMempty) {
-          this.removeChildNodeInstances(this.node1,this.node2);
-          this.isDOMempty = true;
-      }
+      this.removeChildInstances();
 
       if (this.template) {
         var args = this.getTemplateArguments();
@@ -58,9 +50,11 @@ module.exports.$CptTemplate = {
 
   /**
    * Safely cut all dependencies before object is deleted
+   * @param {Boolean} localPropOnly if true only local properties will be deleted (optional)
+   *        must be used when a new instance is created to adapt to a path change
    */
-  $dispose:function() {
-    this.cleanObjectProperties();
+  $dispose:function(localPropOnly) {
+    this.cleanObjectProperties(localPropOnly);
   },
 
   /**

--- a/test/rt/cptbinding.spec.hsp
+++ b/test/rt/cptbinding.spec.hsp
@@ -85,12 +85,12 @@ describe("Component attributes binding", function () {
     var d={value:2,max:100,defaultvalue:42};
     var n=test(d);
 
-    expect(n.node.childNodes.length).to.equal(4);
-    var cptInput=n.node.childNodes[0];
+    expect(n.node.childNodes.length).to.equal(6); // 4+2comments
+    var cptInput=n.node.childNodes[1];
     var c=n.childNodes[0].controller;
-    var valueInput=n.node.childNodes[1];
-    var maxInput=n.node.childNodes[2];
-    var defaultInput=n.node.childNodes[3];
+    var valueInput=n.node.childNodes[3];
+    var maxInput=n.node.childNodes[4];
+    var defaultInput=n.node.childNodes[5];
     
     expect(cptInput.value).to.equal("2");
     expect(valueInput.value).to.equal("2");
@@ -143,8 +143,8 @@ describe("Component attributes binding", function () {
     var n=test2(d);
     checks=[];
 
-    expect(n.node.childNodes.length).to.equal(1);
-    var cptInput=n.node.childNodes[0];
+    expect(n.node.childNodes.length).to.equal(3); // 1+2comments
+    var cptInput=n.node.childNodes[1];
 
     setFieldValue(cptInput,"b");
     expect(checks.length).to.equal(1);

--- a/test/rt/cptwrapper.spec.hsp
+++ b/test/rt/cptwrapper.spec.hsp
@@ -273,8 +273,8 @@ it("tests a component inside another template", function() {
     var n=test(d);
 
     var textInput=n.node.firstChild;
-    var cptInput=n.node.childNodes[1];
-    var cptButton=n.node.childNodes[2];
+    var cptInput=n.node.childNodes[2];
+    var cptButton=n.node.childNodes[3];
     expect(textInput.value).to.equal('42');
     expect(cptInput.value).to.equal('42');
 
@@ -317,7 +317,7 @@ it("tests a component inside another template", function() {
     var d={value:'42'};
     var n=test(d);
 
-    var cptButton=n.node.childNodes[2];
+    var cptButton=n.node.childNodes[3];
 
     fireEvent("click",cptButton);
     hsp.refresh();
@@ -334,7 +334,7 @@ it("tests a component inside another template", function() {
     isBrCbEmpty=false;
     var d={value:'42'};
     var n=test2(d);
-    var cptButton=n.node.childNodes[2];
+    var cptButton=n.node.childNodes[3];
 
     fireEvent("click",cptButton);
     hsp.refresh();

--- a/test/rt/subtemplates1.spec.hsp
+++ b/test/rt/subtemplates1.spec.hsp
@@ -91,8 +91,8 @@ describe("Sub-template insertion", function () {
         var tn = n.childNodes[1].childNodes[0];
 
         expect(n.childNodes.length).to.equal(3);
-        expect(n.node.childNodes.length).to.equal(3);
-        expect(n.node.childNodes[1].nodeValue).to.equal("First Name: Omer");
+        expect(n.node.childNodes.length).to.equal(5); // 3 + 2 comments
+        expect(n.node.childNodes[2].nodeValue).to.equal("First Name: Omer");
         expect(tn.node.nodeValue).to.equal("First Name: Omer");
 
         n.$dispose();
@@ -107,25 +107,25 @@ describe("Sub-template insertion", function () {
         var n = test2(dm);
 
         expect(n.childNodes.length).to.equal(1);
-        expect(n.node.childNodes.length).to.equal(5);
-        expect(n.node.childNodes[0].nodeValue).to.equal("Last Name: Simpson");
-        expect(n.node.childNodes[3].nodeValue).to.equal("First Name: Omer");
+        expect(n.node.childNodes.length).to.equal(11); // 5 + 6 comments
+        expect(n.node.childNodes[2].nodeValue).to.equal("Last Name: Simpson");
+        expect(n.node.childNodes[7].nodeValue).to.equal("First Name: Omer");
 
         // update the data model
         json.set(dm, "firstName", "Marge");
         hsp.refresh();
-        expect(n.node.childNodes[3].nodeValue).to.equal("First Name: Marge");
+        expect(n.node.childNodes[7].nodeValue).to.equal("First Name: Marge");
 
         json.set(dm, "firstName", null);
         hsp.refresh();
-        expect(n.node.childNodes.length).to.equal(3);
+        expect(n.node.childNodes.length).to.equal(7); // 3 + 4 comments
 
         json.set(dm, "firstName", "Mickey");
         json.set(dm, "lastName", "Mouse");
         hsp.refresh();
-        expect(n.node.childNodes.length).to.equal(5);
-        expect(n.node.childNodes[0].nodeValue).to.equal("Last Name: Mouse");
-        expect(n.node.childNodes[3].nodeValue).to.equal("First Name: Mickey");
+        expect(n.node.childNodes.length).to.equal(11);
+        expect(n.node.childNodes[2].nodeValue).to.equal("Last Name: Mouse");
+        expect(n.node.childNodes[7].nodeValue).to.equal("First Name: Mickey");
 
         var n2 = n.childNodes[0].childNodes[1].childNodes[1].childNodes[0];
         expect(n2.node.nodeValue).to.equal("First Name: Mickey");
@@ -141,9 +141,9 @@ describe("Sub-template insertion", function () {
         };
         var n = test3(dm, "Always look on the bright side of life");
 
-        expect(n.node.childNodes.length).to.equal(2);
+        expect(n.node.childNodes.length).to.equal(4); // 2 + 2 comments
         expect(n.node.childNodes[0].nodeValue).to.equal(" Always look on the bright side of life ");
-        expect(n.node.childNodes[1].nodeValue).to.equal("Omer: Simpson");
+        expect(n.node.childNodes[2].nodeValue).to.equal("Omer: Simpson");
 
         n.$dispose();
     });
@@ -196,7 +196,7 @@ describe("Sub-template insertion", function () {
         };
         var n = test5(dm);
 
-        var input = n.node.childNodes[1];
+        var input = n.node.childNodes[2];
         expect(input.value).to.equal("some text");
 
         input.value = "foo";
@@ -219,7 +219,7 @@ describe("Sub-template insertion", function () {
         };
         var n = test6(dm);
 
-        var input = n.node.childNodes[1];
+        var input = n.node.childNodes[2];
         expect(input.value).to.equal("some text");
 
         input.value = "bar";
@@ -239,7 +239,7 @@ describe("Sub-template insertion", function () {
         };
         var n = test6(dm);
 
-        var input = n.node.childNodes[1];
+        var input = n.node.childNodes[2];
         expect(input.value).to.equal("some text");
 
         // change the whole attributes object, which is a root
@@ -259,7 +259,7 @@ describe("Sub-template insertion", function () {
         };
         var n = test7(dm);
 
-        var input = n.node.childNodes[1];
+        var input = n.node.childNodes[2];
         expect(input.value).to.equal("some text");
 
         // change the whole attributes object, which is a root

--- a/test/rt/subtemplates2.spec.hsp
+++ b/test/rt/subtemplates2.spec.hsp
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-var ht=require("hsp/utils/hashtester");
+var ht=require("hsp/utils/hashtester"),
+    klass=require("hsp/klass");
 
 {template test1(c)}
     <div class="content">
@@ -58,6 +59,17 @@ var ht=require("hsp/utils/hashtester");
 
 {template contentB2(msg)}
     contentB2: {msg} 
+{/template}
+
+var C2Controller=klass({
+    attributes:{
+        "msg":{type:"string",defaultValue:"no msg",binding:"1-way"},
+        "foo":{type:"string",defaultValue:"foo"}
+    }
+});
+
+{template contentC2 using c:C2Controller}
+    contentC2: {c.msg} {c.foo} 
 {/template}
 
 var ctxt={
@@ -195,6 +207,61 @@ describe("Dynamic template insertion", function () {
 
         expect(h.logs().length).to.equal(0);
         expect(h(".content").text()).to.equal("Before - This is contentC - After");
+
+        h.$dispose();
+    });
+
+    it("validates dynamic insertion with switch between template and component - template first", function() {
+        var h=ht.newTestContext(), c={tpl:contentA,msg:"hello"};
+        test4(c).render(h.container);
+
+        expect(h.logs().length).to.equal(0);
+        expect(h(".content").text()).to.equal("Before - This is contentA - After");
+
+        // change template to component
+        h.$set(c,"tpl",contentC2);
+        expect(h.logs().length).to.equal(0);
+        expect(h(".content").text()).to.equal("Before - contentC2: hello foo - After");
+        h.$set(c,"msg","hello2");
+        expect(h(".content").text()).to.equal("Before - contentC2: hello2 foo - After");
+
+        // change component to template
+        h.$set(c,"tpl",contentB2);
+
+        expect(h.logs().length).to.equal(0);
+        expect(h(".content").text()).to.equal("Before - contentB2: hello2 - After");
+        h.$set(c,"msg","hello");
+        expect(h(".content").text()).to.equal("Before - contentB2: hello - After");
+
+        // change again
+        h.$set(c,"tpl",contentC2);
+        expect(h.logs().length).to.equal(0);
+        expect(h(".content").text()).to.equal("Before - contentC2: hello foo - After");
+
+        h.$dispose();
+    });
+
+    it("validates dynamic insertion with switch between template and component - component first", function() {
+        var h=ht.newTestContext(), c={tpl:contentC2,msg:"hello"};
+        test4(c).render(h.container);
+
+        expect(h.logs().length).to.equal(0);
+        expect(h(".content").text()).to.equal("Before - contentC2: hello foo - After");
+        h.$set(c,"msg","hello2");
+        expect(h(".content").text()).to.equal("Before - contentC2: hello2 foo - After");
+
+        // change component to template
+        h.$set(c,"tpl",contentB2);
+        expect(h.logs().length).to.equal(0);
+        expect(h(".content").text()).to.equal("Before - contentB2: hello2 - After");
+        h.$set(c,"msg","hello3");
+        expect(h(".content").text()).to.equal("Before - contentB2: hello3 - After");
+
+        // change template to component
+        h.$set(c,"tpl",contentC2);
+
+        expect(h.logs().length).to.equal(0);
+        expect(h(".content").text()).to.equal("Before - contentC2: hello3 foo - After");
 
         h.$dispose();
     });


### PR DESCRIPTION
This PR adds the possibility to change the component type when using a dynamic component reference - in practice this means that a reference can first refer to a template (without controller) or a component (with controller) - and vice versa.

Technically, template and components inherit from different base classes, this is why the solution was to dynamically create a new node instance when a change in component type is detected, and replace the current instance with the new instance. I also made sure that all component types now create surrounding comment nodes (aka. node1 and node2) as they can only be created by the first instance, and are then reused by the next ones.

This fixes issue #233.
