### PR TITLE
improve runtime expression error description - fix #236

### DIFF
--- a/hsp/compiler/jsgenerator/processors.js
+++ b/hsp/compiler/jsgenerator/processors.js
@@ -388,6 +388,11 @@ function formatExpression (expression, firstIndex, walker) {
 
             var generatedPath = [], pathItem;
             generatedPath.push(rootRef);
+            if (exprType === 2 || exprType === 4) {
+                // literal references that don't actually need the root path name
+                // but we still put it in the expression to support better runtime error descriptions 
+                generatedPath.push('"' + path[0].slice(1) + '"');
+            }
             for (var i = 1; i < pathLength; i++) {
                 pathItem = path[i];
                 if ((typeof pathItem) === "string") {

--- a/test/compiler/samples/component4.txt
+++ b/test/compiler/samples/component4.txt
@@ -16,6 +16,6 @@ test=[
   n.elt("input",{e1:[1,2,"d","value"]},{"type":"text","value":["",1]},0),
   n.cpt([_lib,"lib","nbrfield"],{
     e1:[1,2,"d","value"],
-    e2:[4,1,_notifyReset,0,123]
+    e2:[4,1,_notifyReset,"notifyReset",0,123]
   },{"value":["",1],"min":"-10","max":"10"},{"reset":2})
 ]

--- a/test/compiler/samples/component7.txt
+++ b/test/compiler/samples/component7.txt
@@ -12,5 +12,9 @@
 
 ##### Template Code:
 test=[
-  n.cpt([_lib,"lib","nbrfield"],{e1:[6,function(a0,a1) {return {value:a0,min:10,max:"10",reset:a1};},2,3],e2:[1,2,"d","value"],e3:[4,1,_notifyReset,0,123]},{"objliteral":["",1]},0)
+  n.cpt([_lib,"lib","nbrfield"],{
+    e1:[6,function(a0,a1) {return {value:a0,min:10,max:"10",reset:a1};},2,3],
+    e2:[1,2,"d","value"],
+    e3:[4,1,_notifyReset,"notifyReset",0,123]
+  },{"objliteral":["",1]},0)
 ]

--- a/test/compiler/samples/evthandler1.txt
+++ b/test/compiler/samples/evthandler1.txt
@@ -110,7 +110,7 @@ test=[
             {"click":1}
     ),
     n.elt(	"img", 
-            {e1:[4,1,_doClick,0,"blah",1,2],e2:[0,1,"event"]},
+            {e1:[4,1,_doClick,"doClick",0,"blah",1,2],e2:[0,1,"event"]},
             0,
             {"click":1}
     )

--- a/test/compiler/samples/evthandler2.txt
+++ b/test/compiler/samples/evthandler2.txt
@@ -12,7 +12,7 @@
 ##### Template code
 test=[
     n.elt(	"img", 
-            {e1:[4,1,_doClick,0,1]},
+            {e1:[4,1,_doClick,"doClick",0,1]},
             0,
             {"click":1}
     )

--- a/test/compiler/samples/foreach4.txt
+++ b/test/compiler/samples/foreach4.txt
@@ -16,7 +16,7 @@
 ##### Template Code
 test=[
   n.$foreach (
-    {e1:[2,1,_items]},
+    {e1:[2,1,_items,"items"]},
     "itm_key",
     "itm",
     0,

--- a/test/compiler/samples/jsexpression11.txt
+++ b/test/compiler/samples/jsexpression11.txt
@@ -16,7 +16,7 @@ hello=[
         e2:[1,1,"person"],
         e3:[1,2,"person","name"],
         e4:[7,3,function(i,a0,a1) {return [a0,(a1 + 1),"foo"][i];},2,3],
-        e5:[2,2,_x,"y"]},
+        e5:[2,2,_x,"x","y"]},
         ["",1]
     )
 ]

--- a/test/compiler/samples/jsexpression13.txt
+++ b/test/compiler/samples/jsexpression13.txt
@@ -89,7 +89,7 @@
 ##### Template Code
 test=[
   n.$text({
-    e1:[4,1,_orderBy,1,2,0,"firstName"],
+    e1:[4,1,_orderBy,"orderBy",1,2,0,"firstName"],
     e2:[1,2,"person","list"]
   },["",1])
 ]

--- a/test/compiler/samples/jsexpression14.txt
+++ b/test/compiler/samples/jsexpression14.txt
@@ -85,7 +85,7 @@
 ##### Template Code
 test=[
   n.$text({
-    e1:[4,1,_orderBy,1,2,0,"firstName"],
+    e1:[4,1,_orderBy,"orderBy",1,2,0,"firstName"],
     e2:[1,2,"person","list"]
   },["",1])
 ]

--- a/test/compiler/samples/jsexpression15.txt
+++ b/test/compiler/samples/jsexpression15.txt
@@ -145,8 +145,8 @@
 ##### Template Code
 test=[
     n.elt("div",{
-        e1:[4,1,_foo,1,2],
-        e2:[4,1,_bar,1,3,1,5],
+        e1:[4,1,_foo,"foo",1,2],
+        e2:[4,1,_bar,"bar",1,3,1,5],
         e3:[6,function(a0) {return (a0 + "!");},4],
         e4:[1,2,"person","name"],
         e5:[6,function() {return (1 + 2);}]

--- a/test/compiler/samples/jsexpression16.txt
+++ b/test/compiler/samples/jsexpression16.txt
@@ -145,8 +145,8 @@
 ##### Template Code
 test=[
     n.elt("div",{
-        e1:[4,1,_foo,1,2],
-        e2:[4,1,_bar,1,3,1,5],
+        e1:[4,1,_foo,"foo",1,2],
+        e2:[4,1,_bar,"bar",1,3,1,5],
         e3:[6,function(a0) {return (a0 + "!");},4],
         e4:[1,2,"person","name"],
         e5:[6,function() {return (1 + 2);}]

--- a/test/compiler/samples/jsexpression17.txt
+++ b/test/compiler/samples/jsexpression17.txt
@@ -14,7 +14,7 @@
 ##### Template Code
 test=[
   n.$if({
-    e1:[4,1,_acceptEmpty,1,2],
+    e1:[4,1,_acceptEmpty,"acceptEmpty",1,2],
     e2:[1,2,"person","name"]
   },1,[n.$text(0,["hello "])])
 ]

--- a/test/compiler/samples/jsexpression18.txt
+++ b/test/compiler/samples/jsexpression18.txt
@@ -15,7 +15,7 @@
 test=[
   n.$foreach(
     {
-      e1:[4,1,_orderBy,1,2,0,"name"],
+      e1:[4,1,_orderBy,"orderBy",1,2,0,"name"],
       e2:[1,2,"person","list"]
     },
     "p_key",

--- a/test/compiler/samples/jsexpression6.txt
+++ b/test/compiler/samples/jsexpression6.txt
@@ -78,8 +78,8 @@
 ##### Template Code
 test=[
   n.$text({
-    e1:[4,1,_content1],
-    e2:[4,1,_content2,0,"First Name",1,3],
+    e1:[4,1,_content1,"content1"],
+    e2:[4,1,_content2,"content2",0,"First Name",1,3],
     e3:[1,2,"person","firstName"]
   },["Before ",1," ",2," After"])
 ]

--- a/test/compiler/samples/jsexpression7.txt
+++ b/test/compiler/samples/jsexpression7.txt
@@ -13,5 +13,5 @@
 
 ##### Template Code
 test=[
-    n.$text({e1:[4,1,_content1]},["",1])
+    n.$text({e1:[4,1,_content1,"content1"]},["",1])
 ]

--- a/test/compiler/samples/let2.txt
+++ b/test/compiler/samples/let2.txt
@@ -23,7 +23,7 @@ test=[
       n.$text(0,[" "]),
       n.let({
         e1:[1,2,"value","nbr"],
-        e2:[2,1,_blah]
+        e2:[2,1,_blah,"blah"]
       },['aVarName',1,'anotherName',2]
       )
     ],

--- a/test/compiler/samples/let3.txt
+++ b/test/compiler/samples/let3.txt
@@ -19,7 +19,7 @@ test=[
       n.$text(0,[" "]),
       n.let({
         e1:[6,function(a0) {return new a0();},2],
-        e2:[2,1,_Foo],
+        e2:[2,1,_Foo,"Foo"],
         e3:[6,function(a0) {return new a0();},4],
         e4:[1,2,"foo","Bar"]
       },['aVarName',1,'anotherName',3])

--- a/test/compiler/samples/let4.txt
+++ b/test/compiler/samples/let4.txt
@@ -17,8 +17,8 @@ test=[
     "div",0,{"class":"foo"},0,[
       n.let({
         e1:[6,function(a0,a1) {return new a0("a",123,a1);},2,3],
-        e2:[2,1,_Foo],
-        e3:[4,1,_blah,1,4],
+        e2:[2,1,_Foo,"Foo"],
+        e3:[4,1,_blah,"blah",1,4],
         e4:[6,function(a0) {return (1 + a0);},5],
         e5:[1,2,"foo","value"]
       },['val',1])

--- a/test/compiler/samples/text7.txt
+++ b/test/compiler/samples/text7.txt
@@ -12,5 +12,5 @@ var person = {name : "World"};
 
 ##### Template Code
 hello=[
-  n.$text({e1:[2,2,_person,"name"]},["Hello ",1,"!"])
+  n.$text({e1:[2,2,_person,"person","name"]},["Hello ",1,"!"])
 ]

--- a/test/compiler/samples/text8.txt
+++ b/test/compiler/samples/text8.txt
@@ -13,5 +13,5 @@ var nullValue = "null";
 
 ##### Template Code
 main=[
-    n.$text({e1:[2,1,_nullValue]},["before-",1,"-after"])
+    n.$text({e1:[2,1,_nullValue,"nullValue"]},["before-",1,"-after"])
 ]

--- a/test/rt/exprcode.spec.hsp
+++ b/test/rt/exprcode.spec.hsp
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var ht=require("hsp/utils/hashtester");
+
+
+describe("Expression code generation", function () {
+    var h;
+
+    beforeEach(function () {
+         h=ht.newTestContext();
+     });
+
+    afterEach(function () {
+        h.$dispose();
+    });
+
+    it("validates LiteralExpr", function() {
+        {template test()}
+            {123}{"hello"}{false}
+        {/template}
+
+        var exps=test().childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("123");
+        expect(exps["e2"].toCode()).to.equal("\"hello\"");
+        expect(exps["e3"].toCode()).to.equal("false");
+    });
+
+    it("validates DataRefExpr with variables in scope", function() {
+        {template test(msg,person)}
+            {msg}{person.name}
+        {/template}
+
+        var exps=test("hello",{name:"Bart"}).childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("msg");
+        expect(exps["e2"].toCode()).to.equal("person.name");
+    });
+
+    it("validates DataRefExpr with variables out of scope", function() {
+        {template test()}
+            {msg}{person.name}
+        {/template}
+
+        var exps=test().childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("msg");
+        expect(exps["e2"].toCode()).to.equal("person.name");
+    });
+
+    it("validates FuncRefExpr with variables in scope", function() {
+        {template test(foo,person)}
+            {foo()}{foo.bar(123+"hello",person.name,"blah")}
+        {/template}
+
+        var exps=test().childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("foo()");
+        expect(exps["e2"].toCode()).to.equal("foo.bar(123 + \"hello\",person.name,\"blah\")");
+        expect(h.logs().length).to.equal(2);
+        expect(h.logs(0).message).to.equal("Invalid function reference in expression: foo()");
+        expect(h.logs(1).message).to.equal("Invalid function reference in expression: foo.bar(123 + \"hello\",person.name,\"blah\")");
+        h.logs.clear();
+    });
+
+    it("validates FuncRefExpr with variables out of scope", function() {
+        {template test()}
+            {foo()}{foo.bar(123+"hello",person.name,"blah")}
+        {/template}
+
+        var exps=test().childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("foo()");
+        expect(exps["e2"].toCode()).to.equal("foo.bar(123 + \"hello\",person.name,\"blah\")");
+        expect(h.logs().length).to.equal(2);
+        expect(h.logs(0).message).to.equal("Invalid function reference in expression: foo()");
+        expect(h.logs(1).message).to.equal("Invalid function reference in expression: foo.bar(123 + \"hello\",person.name,\"blah\")");
+        h.logs.clear();
+    });
+
+    it("validates FuncExpr", function() {
+        {template test(person)}
+            {123 + 345 * 2}{person.name + 123 * "hello"}
+        {/template}
+
+        var exps=test().childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("123 + (345 * 2)");
+        expect(exps["e2"].toCode()).to.equal("person.name + (123 * \"hello\")");
+    });
+
+    it("validates DynRefExpr 1", function() {
+        {template test(person)}
+            {person["name"]}{person.foo[1+2].blah}
+        {/template}
+
+        var exps=test().childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("person.name");
+        expect(exps["e2"].toCode()).to.equal("person.foo[1 + 2].blah");
+    });
+
+    it("validates DynRefExpr 2", function() {
+        {template test(person)}
+            {person[person.key][12]}
+        {/template}
+
+        var exps=test().childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("person[person.key][12]");
+    });
+
+    it("validates DynRefExpr 3", function() {
+        {template test(person)}
+            {person.foo[1+person.idx*person.age][123].blah["hello"]}
+        {/template}
+
+        var exps=test().childNodes[0].eh.exps;
+        expect(exps["e1"].toCode()).to.equal("person.foo[1 + (person.idx * person.age)][123].blah.hello");
+    });
+});

--- a/test/rt/fnexpressions.spec.hsp
+++ b/test/rt/fnexpressions.spec.hsp
@@ -261,7 +261,7 @@ describe("Function expressions", function () {
         test7(d).render(h.container);
 
         expect(h.logs().length).to.equal(1);
-        expect(h.logs()[0].message).to.equal("[function expression] Object is not a function or has no apply() method: modifier");
+        expect(h.logs()[0].message).to.equal("Object is not a function or has no apply() method: modifier");
         h.logs.clear();
 
         h.$dispose();

--- a/test/rt/index.html
+++ b/test/rt/index.html
@@ -64,6 +64,8 @@
 	require("test/rt/elt.spec.hsp");
 	require("test/rt/evthandler.spec.hsp");
 	require("test/rt/exprbinding.spec.hsp");
+	require("test/rt/exprcode.spec.hsp");
+	require("test/rt/rterrors.spec.hsp");
 	require("test/rt/fnexpressions.spec.hsp");
 	require("test/rt/foreach.spec.hsp");
 	require("test/rt/if.spec.hsp");

--- a/test/rt/rterrors.spec.hsp
+++ b/test/rt/rterrors.spec.hsp
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var ht=require("hsp/utils/hashtester");
+
+
+describe("Runtime errors", function () {
+    var h;
+
+    beforeEach(function () {
+         h=ht.newTestContext();
+     });
+
+    afterEach(function () {
+        h.$dispose();
+    });
+
+    it("should raise an error when global references are used for 2-way binding 1", function() {
+        {template test()}
+            <input type="text" value="{foo}"/>
+        {/template}
+
+        test().render(h.container);
+        h("input").type("bar");
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("Reference cannot be resolved for 2-way data-binding: foo");
+        h.logs.clear();
+    });
+
+    it("should raise an error when global references are used for 2-way binding 2", function() {
+        {template test()}
+            <input type="text" value="{foo.bar}"/>
+        {/template}
+
+        test().render(h.container);
+        h("input").type("bar");
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("Reference cannot be resolved for 2-way data-binding: foo.bar");
+        h.logs.clear();
+    });
+
+    it("should raise an error when global references are used for 2-way binding 3", function() {
+        var foo={};
+
+        {template test()}
+            <input type="text" value="{foo.bar.blah}"/>
+        {/template}
+
+        test().render(h.container);
+        h("input").type("bar");
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("Reference cannot be resolved for 2-way data-binding: foo.bar.blah");
+        h.logs.clear();
+    });
+
+    it("should raise an error when an invalid callback is used", function() {
+        {template test()}
+            <a onclick="{foo()}">click me</a>
+        {/template}
+
+        test().render(h.container);
+        h("a").click();
+        expect(h.logs().length).to.equal(1);
+        expect(h.logs(0).message).to.equal("Invalid function reference in expression: foo()");
+        h.logs.clear();
+    });
+});


### PR DESCRIPTION
This PR improves runtime error descriptions involving expressions. This is done in 3 steps:
- first, by adding a _toCode()_ method to each expression. This method simply rebuilds the expression code from the compiled version.
- second, by modifying the compiler to add an extra parameter to expressions that reference global objects. In the previous implementation the "global" identifiers were indeed not passed, which prevented to see the expression in the error message (this was the case in issue #236)
- and last, by updating the current error descriptions to include a call to _toCode()_

To be complete a 2nd change should be also done to the compiler to pass the file name to the compiled template function (and then include it in all error messages) - but this can be done in a separate PR as code is independent from the current changes.
