### PR TITLE
feat(transpiler): adds options for global mode and variable name

### DIFF
--- a/hsp/transpiler/processAST.js
+++ b/hsp/transpiler/processAST.js
@@ -27,6 +27,14 @@ module.exports = function (ast, options) {
     options = options || {};
     var UglifyJS = options["uglify-js"] || require("uglify-js");
 
+    var mode = options.mode || "commonJS";
+    if (mode !== "global" && mode !== "commonJS") {
+        throw new Error("Invalid compilation mode option: " + mode);
+    }
+
+    var isCommonJS = mode === "commonJS";
+    var setVarName = options.setVarName || "$set";
+
     function getPropertyName (propAccess) {
         if (propAccess instanceof UglifyJS.AST_Dot) {
             return new UglifyJS.AST_String({
@@ -39,7 +47,7 @@ module.exports = function (ast, options) {
 
     function createCallRuntimeMethod (method, args, originalNode) {
         var $setRef = new UglifyJS.AST_SymbolRef({
-            name : "$set"
+            name : setVarName
         });
         var res = new UglifyJS.AST_Call({
             expression : method == "$set" ? $setRef : new UglifyJS.AST_Dot({
@@ -49,7 +57,7 @@ module.exports = function (ast, options) {
             args : args
         });
         res.formatInfo = {
-            before : (method == "$set" ? method : "$set." + method) + "(",
+            before : (method == "$set" ? setVarName : setVarName + "." + method) + "(",
             middle : args,
             after : ")",
             originalStartPos : originalNode.start.pos,
@@ -62,7 +70,7 @@ module.exports = function (ast, options) {
         var res = new UglifyJS.AST_Var({
             definitions : [new UglifyJS.AST_VarDef({
                 name : new UglifyJS.AST_SymbolVar({
-                    name : "$set"
+                    name : setVarName
                 }),
                 value : new UglifyJS.AST_Call({
                     expression : new UglifyJS.AST_SymbolRef({
@@ -131,7 +139,7 @@ module.exports = function (ast, options) {
             changed = true;
             node = replacer(node, aDotB);
         }
-        if (changed && node instanceof UglifyJS.AST_Toplevel) {
+        if (changed && node instanceof UglifyJS.AST_Toplevel && isCommonJS) {
             node.body.unshift(createRequire());
         }
         return node;


### PR DESCRIPTION
This pull request adds support for the following two options in the transpiler:
- mode: either `"commonJS"` (default) or `"global"`, determines whether the transpiler adds the call to require at the beginning of the transpiled file or not
- setVarName: defaults to `"$set"`, determines the name of the variable pointing to the `$set` module

When calling the compiler, the options object is passed directly to the transpiler, so that the existing `mode` option of the compiler is reused in the transpiler.
