### PR TITLE
refactor: simplify and document regexp

### DIFF
--- a/hsp/compiler/treebuilder/syntaxTree.js
+++ b/hsp/compiler/treebuilder/syntaxTree.js
@@ -758,7 +758,8 @@ var SyntaxTree = klass({
         // only called in case of error
         var block = blocks[index];
         var msg = "Invalid HTML element syntax";
-        if (block.code && block.code.match(/^<\/?\@/gi)) {
+        if (block.code && block.code.match(/^<\/?@/)) {
+            //when it starts with <@ or </@
             msg = "Invalid component attribute syntax";
         }
         this._logError(msg, block);


### PR DESCRIPTION
It took me a moment to understand what the given regexp is doing due to 2 reasons:
- AFAIK `@` is not a special char and doesn't need escaping
- Since we are matching beginning of the input we don't need the `g` modifier (?)
- Since we are matching letters we don't need the `i` modifier

Small change but should help with understanding of this code in the future.
