### PR TITLE
chore: retry certain steps on TravisCI to get more stable builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - secure: bGENSGZguDwxsHJu9JyEggr0KhNd9l/RguvlS4zknMV32Hujtt60tsD9X9IKRIO96Fv4loDburOco38SdzezVzd6AS/wsxJsoqD//C2+BXJKzU4MsGXeqS5hx6r2CiTWCnDoIu2QvyK9qiO+Gu0VII76//3pa50m7EVYT79jVxM=
 
 before_install:
- - npm install --quiet -g grunt-cli
- - npm install -g coveralls@2.8.0 &> install-coveralls.log
+ - travis_retry npm install --quiet -g grunt-cli
+ - travis_retry npm install -g coveralls@2.8.0 &> install-coveralls.log
 
 before_script:
  - mkdir -p $LOGS_DIR
@@ -24,7 +24,7 @@ before_script:
  - ./build/sauce/connect_wait.sh
 
 script:
- - grunt ci
+ - travis_retry grunt ci
 
 after_success:
  - cat test-results/*.info test-results/*/*/*.info | coveralls && echo "Successfully sent coverage to https://coveralls.io"


### PR DESCRIPTION
While I'm still looking into ways of getting more stable Sauce tests
there is one simple trick that we can do to increase our chances 
of getting stable builds, see:
http://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/

Of course this is more of a work-around than a proper solution
but I'm afraid that we might need tricks like this one given the 
number of different network-connected machines involved in the 
build process. This seems to be a conclusion from the Travis-CI guys
as well...
