### PR TITLE
fix: throw a descriptive error when an undefined attribute is used for a...

### DIFF
--- a/hsp/rt/cptcomponent.js
+++ b/hsp/rt/cptcomponent.js
@@ -87,7 +87,9 @@ exports.$CptComponent = {
         for (var i = 0, sz = this.atts.length; sz > i; i++) {
           att = atts[i];
           nm = att.name;
-          if (this.ctlAttributes[nm].type!=="template") {
+          if (!this.ctlAttributes || !this.ctlAttributes[nm]) {
+              throw new Error('The attribute "' + nm + '" was used but the component doesn\'t define this attribute.');
+          } else if (this.ctlAttributes[nm].type!=="template") {
             attributes[nm]=att.getValue(eh, pvs, null);
           }
         }

--- a/test/rt/cpterrors.spec.hsp
+++ b/test/rt/cpterrors.spec.hsp
@@ -1,0 +1,51 @@
+var klass=require("hsp/klass"),
+    ht=require("hsp/utils/hashtester");
+
+var FooNoAttrsCtrl=klass({
+});
+
+var FooEmptyAttrsCtrl=klass({
+    attributes: {
+    }
+});
+
+{template fooNoAttrs using ctrl:FooNoAttrsCtrl}
+<div>foo</div>
+{/template}
+
+{template fooEmptyAttrs using ctrl:FooEmptyAttrsCtrl}
+<div>foo</div>
+{/template}
+
+{template test1}
+<#fooNoAttrs foo="bar"></#fooNoAttrs>
+{/template}
+
+{template test2}
+<#fooEmptyAttrs foo="bar"></#fooEmptyAttrs>
+{/template}
+
+describe('error reporting for custom components', function() {
+        
+    var h;
+    beforeEach(function() {
+        h=ht.newTestContext();
+    });
+
+    it('attribute used for a component without attributes', function() {
+        expect(function() {
+            test1().render(h.container);
+        }).to.throwException(/The attribute "foo" was used but the component doesn't define this attribute./);
+    });
+
+    it('attribute used for a component without attributes', function() {
+        expect(function() {
+            test2().render(h.container);
+    }   ).to.throwException(/The attribute "foo" was used but the component doesn't define this attribute./);
+    });
+
+    afterEach(function(){
+        h.$dispose();
+    });
+
+});


### PR DESCRIPTION
... component

Fixes #253

I'm afraid that this is the best I can think of doing based on what I can see being available in the context where the error occurs. Obviously we can't provide the original line number:column as a template is compiled but what is kind of not nice is the fact that we can't (?) provide the impacted component name as it is a function and its constructor seems to be an anonymous function... 

@b-laporte, are there any other sources of data that I'm not aware of and we could use for better error reporting? 
