### PR TITLE
chore: add size tracking for deliverables - part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ after_success:
  - cat test-results/*.info test-results/*/*/*.info | coveralls && echo "Successfully sent coverage to https://coveralls.io"
  - chmod -R 777 ./ci-release.sh
  - ./ci-release.sh
+ - chmod -R 777 ./build/size/size.sh
+ - ./build/size/size.sh dist/!(*.min.js)
 
 after_failure:
   - chmod -R 777 ./build/sauce/connect_logs.sh

--- a/build/size/index.js
+++ b/build/size/index.js
@@ -1,0 +1,29 @@
+var mindthebulk = require('mind-the-bulk');
+var humanize = require('humanize');
+var Table = require('cli-table');
+
+var args = process.argv.slice(2);
+
+if (!args.length) {
+    throw new Error('You need to provide file paths to measure');
+}
+
+var sizes = mindthebulk(args);
+
+//pretty-print results
+var table = new Table({
+    head: ['', 'initial', 'min', 'min+gzip'],
+    colWidths: [40, 15, 15, 15],
+    colAligns: ['left', 'right', 'right', 'right']
+});
+
+sizes.forEach(function (size) {
+    table.push([
+        size.file,
+        humanize.filesize(size.raw),
+        humanize.filesize(size.min),
+        humanize.filesize(size.gzip)
+    ]);
+});
+
+console.log(table.toString());

--- a/build/size/size.sh
+++ b/build/size/size.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+npm install --silent mind-the-bulk humanize cli-table && node build/size $*


### PR DESCRIPTION
In the spirit of "what gets measured gets managed" here is the first part of the size-tracking infrastructure for #space deliverable. This little script will, for now, print out pretty table with file sizes (only when the build is successful). 

Next steps are:
- push results to some (on-line) repository (mongolab?)
- hook it up with GitHub PRs system to have a bot reporting back on GH like coveralls, travis etc.
