### PR TITLE
build: don't execute packaging on npm install

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -358,11 +358,10 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('atpackager');
   require('atpackager').loadNpmPlugin('noder-js');
 
-  grunt.registerTask('prepublish', ['package']);
   grunt.registerTask('package', ['peg', 'browserify', 'atpackager:uglify','atpackager:runtime','uglify']);
   grunt.registerTask('mocha', ['peg', 'inittests', 'mochaTest', 'finalizetests']);
   grunt.registerTask('test', ['checkStyle', 'jscs', 'mocha', 'karma:unit']);
-  grunt.registerTask('ci', ['checkStyle', 'jscs', 'mocha', 'karma:ci1', 'karma:ci2', 'karma:coverage']);
+  grunt.registerTask('ci', ['checkStyle', 'jscs', 'mocha', 'karma:ci1', 'karma:ci2', 'package', 'karma:coverage']);
   grunt.registerTask('release', ['docs:release']);
   grunt.registerTask('tddrt', ['hspserver','watch']);
   grunt.registerTask('default', ['docs:playground']);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "js-yaml": "~2.0.5"
   },
   "scripts": {
-    "test": "grunt test",
-    "prepublish": "grunt prepublish"
+    "test": "grunt test"
   }
 }


### PR DESCRIPTION
Fixes #217

Having the `grunt package` being executed on each npm install is really painful, especially if you are trying to test different versions of npm modules. It also slows down failing builds (if we make mistake in the build like failing validation / test, we should get feedback ASAP).

The potential downside is that we might publish a module that is not well packaged but given that publishing is relatively rare (as compared to build / install operations) and we plan to automate releases, this shouldn't be an issue. In any case the underlying problem (executing npm install on prepublish) should be fixed in the npm itself and there are some discussions about it.

Sending this PR as the current setup makes me loosing way too much time :-/
