### PR TITLE
refactor: use Object.create polyfill

### DIFF
--- a/hsp/es5.js
+++ b/hsp/es5.js
@@ -68,3 +68,20 @@ if (!Function.prototype.bind) {
         return fBound;
     };
 }
+
+//Object.create
+if (typeof Object.create != 'function') {
+    (function () {
+        var F = function () {};
+        Object.create = function (o) {
+            if (arguments.length > 1) {
+                throw Error('Second argument not supported');
+            }
+            if (typeof o != 'object') {
+                throw TypeError('Argument must be an object');
+            }
+            F.prototype = o;
+            return new F();
+        };
+    })();
+}

--- a/hsp/klass.js
+++ b/hsp/klass.js
@@ -38,7 +38,7 @@ var klass = function (klassdef) {
         // create the new prototype from the parent prototype
         if (!klassdef.$extends.prototype)
             throw new Error("[klass] $extends attribute must be a function");
-        var p = createObject(klassdef.$extends.prototype);
+        var p = Object.create(klassdef.$extends.prototype);
 
         // add prototype properties to the prototype and to the constructor function to allow syntax shortcuts
         // such as ClassA.$constructor()
@@ -62,23 +62,6 @@ var klass = function (klassdef) {
 
     return $c;
 };
-
-// helper function used to create object
-function F () {}
-
-/**
- * Create an empty object that extend another object through prototype inheritance
- */
-function createObject (o) {
-    if (Object.create) {
-        return Object.create(o);
-    } else {
-        F.prototype = o;
-        return new F();
-    }
-}
-
-klass.createObject = createObject;
 
 var metaDataCounter = 0;
 /**

--- a/hsp/rt/$root.js
+++ b/hsp/rt/$root.js
@@ -480,7 +480,7 @@ var $CptNode = klass({
     createCptInstance:function(cptType,parent) {
         // build the new type
         var proto1=CPT_TYPES[cptType];
-        var ct = klass.createObject(this);
+        var ct = Object.create(this);
         for (var k in proto1) {
             if (proto1.hasOwnProperty(k)) {
                 ct[k]=proto1[k];
@@ -489,7 +489,7 @@ var $CptNode = klass({
         this.cptType=cptType;
 
         // create node instance
-        var ni=klass.createObject(ct);
+        var ni = Object.create(ct);
         ni.vscope = parent.vscope; // we don't create new named variable in vscope, so we use the same vscope
         ni.parent = parent;
         ni.nodeNS = parent.nodeNS;

--- a/hsp/rt/exphandler.js
+++ b/hsp/rt/exphandler.js
@@ -112,7 +112,7 @@ var ExpHandler = klass({
      * @return {Object} sub-scope object extending the ref object
      */
     createSubScope: function(ref) {
-        var vs = klass.createObject(ref);
+        var vs = Object.create(ref);
         vs["scope"] = vs;
         vs["+parent"] = ref;
         return vs;

--- a/hsp/rt/tnode.js
+++ b/hsp/rt/tnode.js
@@ -171,7 +171,7 @@ var TNode = klass({
      */
     createNodeInstance : function (parent) {
         // create node instance referencing the current node as parent in the prototype chain
-        var ni = klass.createObject(this);
+        var ni = Object.create(this);
         ni.parent = parent;
         if (this.needSubScope) {
             ni.vscope = ni.createSubScope();


### PR DESCRIPTION
I need `Object.create` in the pratt parser and IMO it makes sense to use standard Object.create (with a polyfill if needed). This change doesn't increase LOC and the polyfill can be dropped if one doesn't need to support browsers with non-ES5 JS engines.

Polyfill taken from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
