### PR TITLE
fix(expressions): correct lexer behavior for operators not separated by a whitespace

### DIFF
--- a/hsp/expressions/lexer.js
+++ b/hsp/expressions/lexer.js
@@ -37,8 +37,10 @@ function isOperator(ch) {
     return '+-*/%!|&.,=<>()[]{}?:'.indexOf(ch) > -1;
 }
 
-function isSuffixOperator(ch) {
-    return '=|&'.indexOf(ch) > -1;
+var opSuffixes = {'|': '|', '&' : '&', '=': '=<>!'};
+function isSuffixOperator(ch, previous) {
+    var validPrevious = opSuffixes[ch];
+    return validPrevious && validPrevious.indexOf(previous) > -1;
 }
 
 /**
@@ -79,7 +81,7 @@ module.exports = function (initialInput) {
                     value += current;
                     current = input.charAt(++i);
 
-                } while (isSuffixOperator(current));
+                } while (isSuffixOperator(current, value.charAt(value.length-1)));
 
                 result.push({t: 'opr', v: value, f: from});
 

--- a/test/expressions/lexer.spec.js
+++ b/test/expressions/lexer.spec.js
@@ -174,6 +174,17 @@ describe('lexer', function () {
                 {t: 'opr', v: ')', f: 18}
             ]);
         });
+
+        it('should not treat unknown operators as one token', function() {
+            expect(lexer('d[ppName]|fnSorter')).to.eql([
+                {t: 'idn', v: 'd', f: 0},
+                {t: 'opr', v: '[', f: 1},
+                {t: 'idn', v: 'ppName', f: 2},
+                {t: 'opr', v: ']', f: 8},
+                {t: 'opr', v: '|', f: 9},
+                {t: 'idn', v: 'fnSorter', f: 10}
+            ]);
+        });
     });
 
     describe('error conditions', function () {

--- a/test/expressions/manipulator.spec.js
+++ b/test/expressions/manipulator.spec.js
@@ -132,6 +132,16 @@ describe('getValue', function () {
         expect(expression('all(collection) | item:zero() | item:0').getValue(scope)).to.equal('f');
     });
 
+    it('should evaluate expression where pipe function is an expression', function() {
+        expect(expression('d[ppName]|fnSorter.sort')
+            .getValue({
+               d: {all: ['foo', 'bar']},
+               ppName: 'all',
+               fnSorter: {sort: function(input) {return input.sort();}}
+            }))
+            .to.eql(['bar', 'foo']);
+    });
+
     it('should evaluate expressions containing simple comparison (<, >)', function() {
         expect(expression('1 < 2').getValue({})).to.equal(true);
         expect(expression('1 > 2').getValue({})).to.equal(false);


### PR DESCRIPTION
So, instead of opening one giant PR for all the changes I had to do in order to support pratt expressions in the the `{foreach}` statement, I'm going to open several smaller PRs that are, hopefully, easier to review.

This one corrects how the lexer behaves for expressions like `d[ppName]|fnSorter` - previously it would recognize `]|` as one operator which is obviously wrong.
