### PR TITLE
fix(expression): expr with [] are now assignable

### DIFF
--- a/hsp/expressions/manipulator.js
+++ b/hsp/expressions/manipulator.js
@@ -25,8 +25,8 @@ var evaluator = require('./evaluator');
  */
 module.exports = function(input, inputTree) {
     var tree = inputTree || ast(input);
-    //AST needs to have an identifier or binary . at the root to be assignable
-    var isAssignable = tree.a === 'idn' || (tree.a === 'bnr' && tree.v === '.');
+    //AST needs to have an identifier or binary '.' or '[' at the root to be assignable
+    var isAssignable = tree.a === 'idn' || (tree.a === 'bnr' && (tree.v === '.' || tree.v === '['));
 
     return {
         /**
@@ -56,7 +56,7 @@ module.exports = function(input, inputTree) {
             if (tree.a === 'idn') {
                 scope[tree.v] = newValue;
             } else if (tree.a === 'bnr') {
-                evaluator(tree.l, scope)[tree.r.v] = newValue;
+                evaluator(tree.l, scope)[evaluator(tree.r, scope)] = newValue;
             }
         },
         isAssignable : isAssignable

--- a/test/expressions/manipulator.spec.js
+++ b/test/expressions/manipulator.spec.js
@@ -274,20 +274,36 @@ describe('setValue', function () {
         expect(scope.foo.bar).to.equal('bazzzz');
     });
 
-    it('should set the isAssignable flag set to true for assignable expressions', function () {
-        expect( expression("foo").isAssignable).to.equal(true);
-        expect( expression("foo.bar").isAssignable).to.equal(true);
-        expect( expression("foo.bar.baz").isAssignable).to.equal(true);
+    it('should set values of square brackets assignable expressions', function() {
+        var scope = {
+            foo: {
+                bar: 3
+            },
+            baz: 'bar'
+        };
+        expression("foo['bar']").setValue(scope, 'barrrr');
+        expect(scope.foo.bar).to.equal('barrrr');
+
+        expression("foo[baz]").setValue(scope, 'bazzzz');
+        expect(scope.foo.bar).to.equal('bazzzz');
     });
 
-    it('should set the isAssignable flag set to false for non-assignable expressions', function () {
-        expect( expression("'foo'").isAssignable).to.equal(false);
-        expect( expression("foo === bar").isAssignable).to.equal(false);
-        expect( expression("foo + bar").isAssignable).to.equal(false);
-        expect( expression("foo[bar]").isAssignable).to.equal(false);
-        expect( expression("foo.bar()").isAssignable).to.equal(false);
-        expect( expression("foo ? bar : baz").isAssignable).to.equal(false);
-        expect( expression("foo | bar").isAssignable).to.equal(false);
+    it('should set the isAssignable flag to true for assignable expressions', function () {
+        expect(expression("foo").isAssignable).to.equal(true);
+        expect(expression("foo.bar").isAssignable).to.equal(true);
+        expect(expression("foo.bar.baz").isAssignable).to.equal(true);
+        expect(expression("foo[bar]").isAssignable).to.equal(true);
+        expect(expression("foo.bar[baz]").isAssignable).to.equal(true);
+        expect(expression("foo[bar].baz").isAssignable).to.equal(true);
+    });
+
+    it('should set the isAssignable flag to false for non-assignable expressions', function () {
+        expect(expression("'foo'").isAssignable).to.equal(false);
+        expect(expression("foo === bar").isAssignable).to.equal(false);
+        expect(expression("foo + bar").isAssignable).to.equal(false);
+        expect(expression("foo.bar()").isAssignable).to.equal(false);
+        expect(expression("foo ? bar : baz").isAssignable).to.equal(false);
+        expect(expression("foo | bar").isAssignable).to.equal(false);
     });
 
     it('should throw when a non-assignable expression is set', function () {
@@ -305,4 +321,3 @@ describe('setValue', function () {
 //- non-closed brackets ( [ {
 //- using function call on something that is not a function
 //- using [] . on something that is not an object
-


### PR DESCRIPTION
Expressions like `foo[bar]` were considered as non assignable.
Fix now turn assignable all of these examples

`foo[bar]`
`foo.bar[baz]`
`foo[bar].baz`

Fixes #266
Closes #267
