### PR TITLE
feat: allow objects with the 'apply' method in pipe expressions

### DIFF
--- a/hsp/expressions/evaluator.js
+++ b/hsp/expressions/evaluator.js
@@ -62,7 +62,8 @@ var TERNARY_OPERATORS = {
             undefined : target[name].apply(target, args);
     },
     '?': function (test, trueVal, falseVal) { return test ? trueVal : falseVal; },
-    '|': function (input, pipeFn, args, target) {  //pipe (filter)
+    '|': function (input, pipeFnOrObj, args, target) {  //pipe (filter)
+        var pipeFn = typeof pipeFnOrObj === 'function' ? pipeFnOrObj : pipeFnOrObj['apply'];
         return pipeFn.apply(target, [input].concat(args));
     }
 };

--- a/test/expressions/manipulator.spec.js
+++ b/test/expressions/manipulator.spec.js
@@ -167,6 +167,18 @@ describe('getValue', function () {
         expect(expression('input|selector').getValue(scope)).to.eql('foo');
     });
 
+    it('should allow objects with the "apply" function in pipe expressions', function() {
+        var scope = {
+            input: ['foo', 'bar'],
+            selector: {
+                'apply': function(input) {
+                    return input[1];
+                }
+            }
+        };
+        expect(expression('input|selector').getValue(scope)).to.eql('bar');
+    });
+
     it('should evaluate expressions containing simple comparison (<, >)', function() {
         expect(expression('1 < 2').getValue({})).to.equal(true);
         expect(expression('1 > 2').getValue({})).to.equal(false);


### PR DESCRIPTION
This adds possibility to use objects with the `apply` method in pipe expressions. 

I didn't address corner cases in this PR (ex.: trying to invoke something that is not a function) as we've got a separate issue for this (https://github.com/ariatemplates/hashspace/issues/236) and I plan to review error handling in there.
