### PR TITLE
refactor: use Pratt's parser in {foreach} expressions

### DIFF
--- a/hsp/compiler/treebuilder/syntaxTree.js
+++ b/hsp/compiler/treebuilder/syntaxTree.js
@@ -518,12 +518,7 @@ var SyntaxTree = klass({
         var node = new Node("foreach"), block = blocks[index];
         node.item = block.item;
         node.key = block.key;
-        //node.collection = block.colref;
-        //node.collection.bound = true;
-
-        var expr = new HExpression(block.colref, this);
-        node.collection = expr.getSyntaxTree();
-        node.collection.bound = true;
+        node.collection = block.colref;
 
         node.content = [];
         out.push(node);

--- a/hsp/expressions/evaluator.js
+++ b/hsp/expressions/evaluator.js
@@ -64,7 +64,7 @@ var TERNARY_OPERATORS = {
     '?': function (test, trueVal, falseVal) { return test ? trueVal : falseVal; },
     '|': function (input, pipeFnOrObj, args, target) {  //pipe (filter)
         var pipeFn = typeof pipeFnOrObj === 'function' ? pipeFnOrObj : pipeFnOrObj['apply'];
-        return pipeFn.apply(target, [input].concat(args));
+        return pipeFn.apply(typeof pipeFnOrObj === 'function' ? target : pipeFnOrObj, [input].concat(args));
     }
 };
 

--- a/test/compiler/samples/comment.txt
+++ b/test/compiler/samples/comment.txt
@@ -23,7 +23,7 @@
       {"type": "text","value": "Hello "},
       {"type": "comment","value": " comment 1"},
       {"type": "text","value": " World! "},
-      {"type": "if", "condition": {category:"jsexptext", value:"(world)"}},
+      {"type": "if", "condition": {category:"jsexptext", value:"world"}},
       {"type": "text","value": " "},
       {"type": "comment","value": " comment 2"},
       {"type": "text","value": " "},
@@ -49,9 +49,9 @@
         "type": "if",
         "condition": {
           "category": "jsexptext",
-          "value": "(world)",
+          "value": "world",
           "line": 4,
-          "column": 6
+          "column": 7
         },
         "content1": [
           {
@@ -67,7 +67,7 @@
 ##### Template Code
 hello=[__s,
   n.$text(0,["Hello  World!"]),
-  n.$if( {e1:[9,"(world)"]}, 1, [
+  n.$if( {e1:[9,"world"]}, 1, [
       n.$text(0,["   ... "])
   ])
 ]

--- a/test/compiler/samples/foreach1.txt
+++ b/test/compiler/samples/foreach1.txt
@@ -15,11 +15,8 @@
       {"type": "text","value": "Foreach test: "},
       {"type": "foreach","item":"thing","key":"thing_key",
         "colref": {
-          "type": "Variable",
-          "name": "things",
-          "code": "things",
-          "category": "jsexpression",
-          "expType": "Variable",
+          "category": "jsexptext",
+          "value": "things",
           "line": 3,
           "column": 22
         }
@@ -43,10 +40,8 @@
       {"type": "text","value": "Foreach test: "},
         {"type": "foreach","item":"thing","key":"thing_key",
         "collection": {
-            "type": "expression",
-            "category": "objectref",
-            "bound": true,
-            "path": [ "things" ],
+            "category": "jsexptext",
+            "value": "things",
             "line": 3,
             "column": 22
         },
@@ -65,7 +60,7 @@
 ##### Template Code
 test=[__s,
   n.$text(0,["Foreach test:  "]),
-  n.$foreach({e1: [1, 1, "things"]}, "thing_key", "thing", 0 , 1, [
+  n.$foreach({e1: [9, "things"]}, "thing_key", "thing", 0 , 1, [
     n.$text({e1: [1, 1, "thing"]}, [" - ", 1, " - "])
   ])
 ]

--- a/test/compiler/samples/foreach2.txt
+++ b/test/compiler/samples/foreach2.txt
@@ -21,12 +21,8 @@
     "content": [
       {"type": "foreach","item":"name","key":"k",
         "colref": {
-          "type": "PropertyAccess",
-          "base": { "type": "Variable", "name": "passengers", "code": "passengers"},
-          "name": "names",
-          "code": "passengers.names",
-          "category": "jsexpression",
-          "expType": "PropertyAccess",
+          "value": "passengers.names",
+          "category": "jsexptext",
           "line": 2,
           "column": 22
         }
@@ -58,10 +54,8 @@
     "content": [
       {"type": "foreach","item":"name","key":"k",
         "collection": {
-          "type": "expression",
-          "category": "objectref",
-          "bound": true,
-          "path": [ "passengers", "names" ],
+          "category": "jsexptext",
+          "value": "passengers.names",
           "line": 2,
           "column": 22
         },
@@ -94,7 +88,7 @@
 
 ##### Template Code
 test=[__s,
-  n.$foreach({e1: [1,2,"passengers","names"]}, "k", "name", 0 , 1, [
+  n.$foreach({e1: [9,"passengers.names"]}, "k", "name", 0 , 1, [
     n.$if( {e1:[9,"name_isfirst"]}, 1, [
         n.$text(0,["<< "])
     ]),

--- a/test/compiler/samples/foreach3.txt
+++ b/test/compiler/samples/foreach3.txt
@@ -19,12 +19,8 @@
       {"type": "element","name": "div","closed": false,"attributes": []},
       {"type": "foreach","item":"name","key":"k",
         "colref": {
-          "type": "PropertyAccess",
-          "base": { "type": "Variable", "name": "passengers", "code": "passengers" },
-          "name": "names",
-          "code": "passengers.names",
-          "category": "jsexpression",
-          "expType": "PropertyAccess",
+          "category": "jsexptext",
+          "value": "passengers.names",
           "line": 3,
           "column": 24
         }
@@ -48,10 +44,8 @@
       {"type": "element","name": "div","closed": false,"attributes": [],"content": [
           {"type": "foreach","item": "name","key": "k", 
             "collection": {
-              "type": "expression",
-              "category": "objectref",
-              "bound": true,
-              "path": [ "passengers", "names" ],
+              "category": "jsexptext",
+              "value": "passengers.names",
               "line": 3,
               "column": 24
             },
@@ -73,7 +67,7 @@ test=[__s,
       0,
       0,
       [
-        n.$foreach( {e1: [1,2,"passengers","names"]}, "k", "name", 0 , 1, [
+        n.$foreach( {e1: [9,"passengers.names"]}, "k", "name", 0 , 1, [
           n.$text(0 ,["x "])
         ]),
         n.$text(0 ,[" "])

--- a/test/compiler/samples/foreach4.txt
+++ b/test/compiler/samples/foreach4.txt
@@ -16,7 +16,7 @@
 ##### Template Code
 test=[__s,
   n.$foreach (
-    {e1:[2,1,_items]},
+    {e1:[9, "items"]},
     "itm_key",
     "itm",
     0,

--- a/test/compiler/samples/if2.txt
+++ b/test/compiler/samples/if2.txt
@@ -24,7 +24,7 @@
         "category": "jsexptext",
         "value": "v1.isWorld"
       }},
-      {"type": "if", "condition": {"category": "jsexptext", "value":"(v2)"}},
+      {"type": "if", "condition": {"category": "jsexptext", "value":"v2"}},
       {"type": "text","value": "World "},
       {"type": "else"},
       {"type": "text","value": "Mate! "},
@@ -47,7 +47,7 @@
         "condition": {"category": "jsexptext", "value": "v1.isWorld"},
         "content1": [
           {"type": "if",
-            "condition": {"category": "jsexptext", "value": "(v2)"},
+            "condition": {"category": "jsexptext", "value": "v2"},
             "content1": [
               {"type": "text", "value": "World "}
             ],
@@ -65,7 +65,7 @@
 test=[__s,
   n.$text(0,["Hello "]),
   n.$if( {e1:[9,"v1.isWorld"]}, 1, [
-    n.$if( {e1:[9,"(v2)"]}, 1, [
+    n.$if( {e1:[9,"v2"]}, 1, [
         n.$text(0,["World "])
     ],[
         n.$text(0,["Mate! "])

--- a/test/compiler/samples/if3.txt
+++ b/test/compiler/samples/if3.txt
@@ -20,7 +20,7 @@
       {"type": "if", "condition": {"category": "jsexptext", "value": "123.4"}},
       {"type": "text","value": " Number "},
       {"type": "endif"},
-      {"type": "if", "condition": {"category": "jsexptext", "value": "('ok')"}},
+      {"type": "if", "condition": {"category": "jsexptext", "value": "'ok'"}},
       {"type": "text","value": " String1 "},
       {"type": "endif"},
       {"type": "if", "condition": {"category": "jsexptext", "value": '"o\\"k"'}},
@@ -51,7 +51,7 @@
         ]
       },
       {"type": "if",
-        "condition": {"category": "jsexptext", "value": "('ok')"},
+        "condition": {"category": "jsexptext", "value": "'ok'"},
         "content1": [
           {"type": "text", "value": " String1 "}
         ]
@@ -74,7 +74,7 @@ test=[__s,
   n.$if( {e1:[9,"123.4"]}, 1, [
     n.$text(0,[" Number "])
   ]),
-  n.$if( {e1:[9,"('ok')"]}, 1, [
+  n.$if( {e1:[9,"'ok'"]}, 1, [
     n.$text(0,[" String1 "])
   ]),
   n.$if( {e1:[9,"\"o\"k\""]}, 1, [

--- a/test/compiler/samples/jsexpression1.txt
+++ b/test/compiler/samples/jsexpression1.txt
@@ -15,7 +15,7 @@
     "content": [
       {"type": "if", "condition": {
       	"category": "jsexptext",
-      	"value": '(value === "test" || value===false || value===null || value===123)'
+      	"value": 'value === "test" || value===false || value===null || value===123'
       }},
       {"type": "text","value": "World "},
       {"type": "endif"}
@@ -35,7 +35,7 @@
       { "type": "if",
         "condition": {
           "category": "jsexptext",
-          "value": '(value === "test" || value===false || value===null || value===123)'
+          "value": 'value === "test" || value===false || value===null || value===123'
         },
         "content1": [
           {"type": "text","value": "World "}
@@ -48,7 +48,7 @@
     
 ##### Template Code
 test=[__s,
-  n.$if( {e1:[9,"(value === \"test\" || value===false || value===null || value===123)"]}, 1, [
+  n.$if( {e1:[9,"value === \"test\" || value===false || value===null || value===123"]}, 1, [
       n.$text(0,["World "])
   ])
 ]

--- a/test/compiler/samples/jsexpression18.txt
+++ b/test/compiler/samples/jsexpression18.txt
@@ -15,8 +15,7 @@
 test=[__s,
   n.$foreach(
     {
-      e1:[4,1,_orderBy,1,2,0,"name"],
-      e2:[1,2,"person","list"]
+      e1:[9,"person.list|orderBy:\"name\""]
     },
     "p_key",
     "p",

--- a/test/rt/foreach.spec.hsp
+++ b/test/rt/foreach.spec.hsp
@@ -656,8 +656,7 @@ describe("ForEach Node", function () {
         items.push({value:"Item C"});
         h.refresh();
 
-        // no binding - so nbr of items should be the same
-        expect(h(".itm").length).to.equal(2);
+        expect(h(".itm").length).to.equal(3);
 
         h.$dispose();
     });


### PR DESCRIPTION
So, after all the other changes that landed here is a PR that introduces Pratt's-alg-parsed expression in the {foreach} blocks. But this PR mostly changes how brackets around {if} / {foreach} expression are handled - that is - those are never part of the expression now.

@b-laporte would be great if you could review this one, especially peg grammar changes as  I feel this could be simplified - not sure how, though...
