### PR TITLE
feat(expressions): support assigment = operator

### DIFF
--- a/hsp/expressions/parser.js
+++ b/hsp/expressions/parser.js
@@ -141,6 +141,22 @@ prefix("{", function () {
     this.a = 'unr';
     return this;
 });
+infixr("=", 10, function (left) {
+    if (left.a === "idn") {
+        this.l = left;
+        this.l.a = "literal";
+        this.r = expression(9);
+        this.a = "bnr";
+    } else if (left.id === "." || left.id === "[") {
+        this.l = left.l;
+        this.r = left.r;
+        this.othr = expression(9);
+        this.a = "tnr";
+    } else {
+        throw new Error("Invalid left-hand side in assignment: " + left.id);
+    }
+    return this;
+});
 infix("?", 20, function (left) {
     this.l = left;
     this.r = expression(0);

--- a/test/expressions/manipulator.spec.js
+++ b/test/expressions/manipulator.spec.js
@@ -299,6 +299,32 @@ describe('getValue with defaults', function () {
             expect(expression("{}").getValue({}, 5)).to.eql({});
         });
     });
+
+    describe('assignment operator', function () {
+        it('should allow assignments in simple expressions', function() {
+            var scope = {foo: 'bar'};
+            expression("foo='baz'").getValue(scope);
+            expect(scope.foo).to.equal('baz');
+        });
+
+        it('should allow assignments in expressions with dots', function() {
+            var scope = {foo: {bar: 'bar'}};
+            expression("foo.bar='baz'").getValue(scope);
+            expect(scope.foo.bar).to.equal('baz');
+        });
+
+        it('should allow assignments in expressions with dynamic parts', function() {
+            var scope = {foo: {bar: 'bar'}};
+            expression("foo['bar']='baz'").getValue(scope);
+            expect(scope.foo.bar).to.equal('baz');
+        });
+
+        it('should allow assignments in expressions with very dynamic parts', function() {
+            var scope = {foo: {bar: 'bar'}, idx: 'bar'};
+            expression("foo[idx]='baz'").getValue(scope);
+            expect(scope.foo.bar).to.equal('baz');
+        });
+    });
 });
 
 describe('setValue', function () {


### PR DESCRIPTION
This adds support for the assignment operator (only `=`, no support for `+=` etc.). We need assignment operators in the `{let}` blocks. Additionally we might want to introduce them in expressions showing up in event handlers so one will be able to write sth like this:

``` javascript
<a onclick="{ctrl.show = !ctrl.show}">Toggle me!</a>
```
