### PR TITLE
Template runtime filescope was wrongly renitialized

### DIFF
--- a/hsp/rt.js
+++ b/hsp/rt.js
@@ -133,7 +133,7 @@ refresh.addTemplate = function (tpl) {
  */
 exports.template = function (arg, contentFunction) {
     // closure variables
-    var ng = new NodeGenerator(null), args = [], sz = 0, hasController = false, Ctl = null;
+    var ng = new NodeGenerator(null), args = [], sz = 0, hasController = false, Ctl = null, fileScope;
     if (arg.constructor === Array) {
         sz = arg.length;
         for (var i = 0; sz > i; i++) {
@@ -162,7 +162,7 @@ exports.template = function (arg, contentFunction) {
     }
 
     var f = function () {
-        var cw = null, cptInitArgs = null, fileScope;
+        var cw = null, cptInitArgs = null;
         if (!ng.nodedefs) {
             try {
                 var r = contentFunction(nodes);

--- a/test/rt/filescope.spec.hsp
+++ b/test/rt/filescope.spec.hsp
@@ -1,0 +1,52 @@
+
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var hsp=require("hsp/rt"),
+    ht=require("hsp/utils/hashtester");
+
+
+function globalHelper() {
+    return true;
+}
+
+{template test1}
+    {if (globalHelper())}
+        <div class="test">I am here because of a global helper</div>
+    {/if}
+{/template}
+
+{template test2}
+  <#test1 />
+  <#test1 />
+{/template}
+
+describe("Templates using expressions with global references", function () {
+
+    it("should actually access the reference", function () {
+        var h = ht.newTestContext();
+        test1().render(h.container);
+        expect(h.container.childNodes[1].innerHTML).to.equal("I am here because of a global helper");
+        h.$dispose();
+    });
+
+    it("should be rendered more than once w/ no error", function () {
+        var h = ht.newTestContext();
+        test2().render(h.container);
+        expect(h(".test").length).to.equal(2);
+        h.$dispose();
+    });
+
+});

--- a/test/rt/index.html
+++ b/test/rt/index.html
@@ -64,6 +64,7 @@
 	require("test/rt/elt.spec.hsp");
 	require("test/rt/evthandler.spec.hsp");
 	require("test/rt/exprbinding.spec.hsp");
+	require("test/rt/filescope.spec.hsp");
 	require("test/rt/fnexpressions.spec.hsp");
 	require("test/rt/foreach.spec.hsp");
 	require("test/rt/if.spec.hsp");
@@ -89,9 +90,7 @@
 	require("test/gestures/pinch.spec.hsp");
 	require("test/utils/eventgenerator.spec.hsp");
 	require("test/utils/hashtester.spec.hsp");
-	require("docs/todomvc/test/todo.spec.js");
 	mocha.checkLeaks();
-	//mocha.globals(['jQuery']);
 	mocha.run();
 
 	</script>


### PR DESCRIPTION
The filescope injected by the compiler inside the template function
was properly retrieved during initialization.
But then, the variable being wrongly defined as a closure variable,
it was reinitialized and not reassigned on subsequent calls.
