### PR TITLE
fix #207 HTML comments are not generated in the DOM

### DIFF
--- a/hsp/compiler/jsgenerator/processors.js
+++ b/hsp/compiler/jsgenerator/processors.js
@@ -104,6 +104,21 @@ exports["text"] = function (node, walker) {
 };
 
 /**
+ * Generates a comment node.
+ * @param {Node} node the current Node object as built by the treebuilder.
+ * @param {TreeWalker} walker the template walker instance.
+ * @return {String} a snippet of Javascript code built from the node.
+ */
+exports["htmlcomment"] = function (node, walker) {
+    if (node.value === undefined) {
+        console.dir(node);
+        return "n.$comment(\"\")";
+    }
+
+    return ["n.$comment(\"", escapeNewLines(node.value.replace(/"/g, "\\\"")), "\")"].join('');
+};
+
+/**
  * For a given value double it's definition returning "value",value.
  * This method should only be called on object literals (strings).
  * @param {String} value the initial value.

--- a/hsp/compiler/parser/hspblocks.pegjs
+++ b/hsp/compiler/parser/hspblocks.pegjs
@@ -135,7 +135,7 @@ CommentBlock
 
 HTMLCommentBlock
   = "<!--" chars:HTMLCommentChar* "-->"
-  {return {type:"comment", value:chars.join('')}}
+  {return {type:"htmlcomment", value:chars.join(''), line:line, column:column}}
 
 HTMLCommentChar
   = !"-" "-" !">" {return "-"}

--- a/hsp/compiler/treebuilder/syntaxTree.js
+++ b/hsp/compiler/treebuilder/syntaxTree.js
@@ -779,6 +779,22 @@ var SyntaxTree = klass({
     },
 
     /**
+     * Manages HTML comment blocks.
+     * @param {Array} blocks the full list of blocks.
+     * @param {Integer} index the index of the block to manage.
+     * @param {Array} out the output as an array of Node.
+     * @return {Integer} the index of the block where the function stopped or -1 if all blocks have been handled.
+     */
+    __htmlcomment : function (index, blocks, out) {
+        var node = new Node("htmlcomment"), block = blocks[index];
+        node.value = block.value;
+        node.line = block.line;
+        node.column = block.column;
+        out.push(node);
+        return index;
+    },
+
+    /**
      * Captures isolated end elements to raise an error.
      * @param {Array} blocks the full list of blocks.
      * @param {Integer} index the index of the block to manage.

--- a/hsp/rt.js
+++ b/hsp/rt.js
@@ -266,6 +266,7 @@ var nodes = {};
 
 var nodeList = [
     "$text", require("./rt/$text"),
+    "$comment", require("./rt/$comment"),
     "$if", require("./rt/$if"),
     "$foreach", require("./rt/$foreach"),
     "elt", require("./rt/eltnode"),

--- a/hsp/rt/$comment.js
+++ b/hsp/rt/$comment.js
@@ -1,0 +1,56 @@
+
+/*
+ * Copyright 2012 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This module contains the comment node
+var klass = require("../klass"),
+    doc = require("./document"),
+    TNode = require("./tnode").TNode;
+
+var $CommentNode = klass({
+    $extends : TNode,
+
+    /**
+     * Comment node generator.
+     * @param {Map<Expression>|int} exps the map of the variables used by the node. 0 is passed if no expression is
+     * used
+     * @param {String} comment the value of the comment
+     */
+    $constructor : function (comment) {
+        TNode.$constructor.call(this, 0);
+        this.comment = comment;
+    },
+
+    /**
+     * Create the DOM comment element and attach it to the parent
+     */
+    createNode : function () {
+        this.node = doc.createComment(this.comment);
+    },
+
+    /**
+     * Return the component attribute type of the current node
+     * @return {String} one of the following option:
+     *      "ATTELT" if the element is an attribute element (e.g. <@body>)
+     *      "CONTENT" if the node is a content element (e.g. <div>)
+     *      "INDEFINITE" if the element can be part of eithe an attribute or content collection (e.g. blank text nodes)
+     *      "ERROR" if elt mixes attribute and content elements
+     */
+    getCptAttType: function() {
+        return "CONTENT";
+    }
+});
+
+module.exports = $CommentNode;

--- a/test/compiler/samples/comment.txt
+++ b/test/compiler/samples/comment.txt
@@ -27,7 +27,7 @@
       {"type": "text","value": " "},
       {"type": "comment","value": " comment 2"},
       {"type": "text","value": " "},
-      {"type": "comment","value": " another comment\n\t   on multiple \n\t   lines \n\t   {/template}\n\t   "},
+      {"type": "htmlcomment","value": " another comment\n\t   on multiple \n\t   lines \n\t   {/template}\n\t   "},
       {"type": "text","value": " ... "},
       {"type": "endif"}
     ]
@@ -56,7 +56,17 @@
         "content1": [
           {
             "type": "text",
-            "value": "   ... "
+            "value": "  "
+          },
+          {
+            "type": "htmlcomment",
+            "value": " another comment\n\t   on multiple \n\t   lines \n\t   {/template}\n\t   ",
+            "line": 5,
+            "column": 5
+          },
+          {
+            "type": "text",
+            "value": " ... "
           }
         ]
       }
@@ -68,6 +78,8 @@
 hello=[__s,
   n.$text(0,["Hello  World!"]),
   n.$if( {e1:[9,"world"]}, 1, [
-      n.$text(0,["   ... "])
+      n.$text(0,["  "]),
+      n.$comment(" another comment\n     on multiple \n     lines \n     {/template}\n     "),
+      n.$text(0,[" ... "])
   ])
 ]

--- a/test/rt/comment.spec.hsp
+++ b/test/rt/comment.spec.hsp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014 Amadeus s.a.s.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var hsp = require("hsp/rt"),
+    klass = require("hsp/klass");
+
+{template test1()}
+    <!-- <span>this is a comment
+    on multiple lines</span> -->
+{/template}
+
+{template test2()}
+    <div>
+        <!-- <span>this is a comment
+        on multiple lines</span> -->
+    </div>
+{/template}
+
+{template test3()}
+    <div>
+        <#test1/>
+    </div>
+{/template}
+
+// sample controller
+SimpleController = klass({
+  attributes: {
+    "expanded":{type:"boolean",binding:"2-way"}
+  }
+});
+
+// sample panel template
+{template simple using c:SimpleController}
+    <!-- <span>this is a comment
+    on multiple lines</span> -->
+{/template}
+
+{template test4()}
+    <div>
+        <#simple/>
+    </div>
+{/template}
+
+describe("Comment Nodes", function () {
+    var COMMENT_NODE = 8;
+
+    it("validates a HTML comment in a template", function() {
+        var n = test1();
+        expect(n.node.firstChild.nodeType).to.equal(COMMENT_NODE);
+        expect(n.node.firstChild.nodeValue).to.equal(" <span>this is a comment\n    on multiple lines</span> ");
+        n.$dispose();
+    });
+
+    it("validates a HTML comment in an element", function() {
+        var n = test2();
+        expect(n.node.firstChild.firstChild.nodeType).to.equal(COMMENT_NODE);
+        expect(n.node.firstChild.firstChild.nodeValue).to.equal(" <span>this is a comment\n        on multiple lines</span> ");
+        n.$dispose();
+    });
+
+    it("validates a HTML comment in a sub template", function() {
+        var n = test3();
+        expect(n.node.firstChild.childNodes[1].nodeType).to.equal(COMMENT_NODE);
+        expect(n.node.firstChild.childNodes[1].nodeValue).to.equal(" <span>this is a comment\n    on multiple lines</span> ");
+        n.$dispose();
+    });
+
+    it("validates a HTML comment in a component", function() {
+        var n = test4();
+        expect(n.node.firstChild.childNodes[1].nodeType).to.equal(COMMENT_NODE);
+        expect(n.node.firstChild.childNodes[1].nodeValue).to.equal(" <span>this is a comment\n    on multiple lines</span> ");
+        n.$dispose();
+    });
+});

--- a/test/rt/index.html
+++ b/test/rt/index.html
@@ -50,6 +50,7 @@
 	require("test/rt/global.spec.hsp");
 	require("test/rt/colutils.spec.js");
 	require("test/rt/booleanAttributes.spec.hsp");
+	require("test/rt/comment.spec.hsp");
 	require("test/rt/cptattelements1.spec.hsp");
 	require("test/rt/cptattelements2.spec.hsp");
 	require("test/rt/cptattelements3.spec.hsp");


### PR DESCRIPTION
To solve issue #207, this PR creates a new $comment node in Hashspace. Please review.
