### PR TITLE
feat(syntax) change {template} to <template>

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -40,13 +40,13 @@ TBD
 
 #### Template definition
 
-Inside an `.hsp` file, you can define a template using `{template}` statement. A single `.hsp` can define multiple templates.
+Inside an `.hsp` file, you can define a template using `<template>` statement. A single `.hsp` can define multiple templates.
 
 ```cs
-{template tplname(arg1, arg2)}
+<template tplname(arg1, arg2)>
   //your template code goes here
   <div>Hello world</div>
-{/template}
+</template>
 ```
 
 A template has the following properties:
@@ -75,7 +75,7 @@ This statement is a block statement.
 Note that as a kind of alternative, in some cases a ternary expression can be used instead of the statement.
 
 ```cs
-{template example(context)}
+<template example(context)>
   Number is:
   {if context.number < 0}
     negative
@@ -85,7 +85,7 @@ Note that as a kind of alternative, in some cases a ternary expression can be us
     null
   {/if}
   &nbsp;({context.number === 0 ? 'null' : context.number}).
-{/template}
+</template>
 ```
 
 ---
@@ -99,13 +99,13 @@ This statement is a block statement.
 Note that the statement creates its own local environment containing the reference to the current value and possibly the one to the current index.
 
 ```cs
-{template example(array)}
+<template example(array)>
   <ul>
   {foreach index, value in array}
     <li onclick="{process(value)}">{index}: {value}</li>
   {/foreach}
   </ul>
-{/template}
+</template>
 ```
 
 ---
@@ -156,9 +156,9 @@ It will forward all the given parameters, and add its own metadata with the foll
 * `column`: the column number in which the statement appears on the line
 
 ```cs
-{template example()}
+<template example()>
   {log scope}
-{/template}
+</template>
 ```
 
 ---
@@ -181,7 +181,7 @@ The scope of the created variable is the container block in which the statement 
 `{let}` statements __MUST__ appear at the beginning of the blocks in which they are used!
 
 ```hashspace
-{template example()}
+<template example()>
   {let tpl = "Variable in template environment"}
 
   <div>
@@ -199,12 +199,12 @@ The scope of the created variable is the container block in which the statement 
   {foreach value in container}
     {let foreach_ = "Variable in foreach environment"}
   {/foreach}
-{/template}
+</template>
 ```
 
 ---
 
-#### Component template definitions `{template mycpt using ctrl:MyController}`
+#### Component template definitions `<template mycpt using ctrl:MyController>`
 
 Defines a component, that is a template tied to a specific _class_ to be used as controller.
 
@@ -225,7 +225,7 @@ The above means mainly two important things:
 * parameters of the template (equivalent of element attributes) are __passed by name__, not by position
 * it not only instantiates the template but also renders it automatically in a DOM element inserted exactly where the statement is used
 
-There is also an additional subtlety regarding the passing of the parameters. As said, they are passed by name, so if you use `<tplref arg1="..." />` for a template defined like this `{template(whatever, arg1)}`, `arg1` will be properly passed, wherever it is defined in the parameters list. However the actual subtlety resides in the __first__ parameter of the function: if it doesn't match any attribute name, it is not left `undefined` as one could think. Instead, it refers to an object built from the attribute/value pairs. In our little example, `whatever` would refer to an object like this: `{arg1: "..."}`. This is implicitely due to the internal way hashspace is managing components instantiation (components are discussed later in this documentation).
+There is also an additional subtlety regarding the passing of the parameters. As said, they are passed by name, so if you use `<tplref arg1="..." />` for a template defined like this `<template(whatever, arg1)>`, `arg1` will be properly passed, wherever it is defined in the parameters list. However the actual subtlety resides in the __first__ parameter of the function: if it doesn't match any attribute name, it is not left `undefined` as one could think. Instead, it refers to an object built from the attribute/value pairs. In our little example, `whatever` would refer to an object like this: `{arg1: "..."}`. This is implicitely due to the internal way hashspace is managing components instantiation (components are discussed later in this documentation).
 
 __Reference__:
 
@@ -349,9 +349,9 @@ This means that instead of giving a piece of JavaScript code to be executed in t
 Event handlers have a particularity though: in your function call, you can pass the `event` object to your handler function. This `event` object is implicitly available in the context of your expression, but it is not automatically passed, so you need to explicitly pass it if you want to have it available in your function.
 
 ```cs
-{template example()}
+<template example()>
   <span onclick="{handler(event)}">Click me</span>
-{/template}
+</template>
 
 function handler(event) {
   // ...
@@ -528,14 +528,14 @@ Hashspace natively supports different types of attributes:
   ```
 
   ```cs
-  {template mycpt using ctrl:MyCpt}
+  <template mycpt using ctrl:MyCpt>
     <header>
       <#ctrl.header />
     </header>
     <section>
       <#ctrl.body />
     </section>
-  {/template}
+  </template>
   ```
 
   In terms of usage, it would be done with several different syntaxes:
@@ -692,13 +692,13 @@ var Controller = klass({
   }
 });
 
-{template example using controller:Controller}
+<template example using controller:Controller>
   <div>
     <span></span>
   </div>
   Ignored text
   <hr />
-{/template}
+</template>
 ```
 
 ---

--- a/docs/playground/layout.hsp
+++ b/docs/playground/layout.hsp
@@ -29,7 +29,7 @@ var DescriptionCtrl = Class({
     }
 });
 
-{template desc using ctrl:DescriptionCtrl}
+<template desc using ctrl:DescriptionCtrl>
     <div id="description">
         {if ctrl.sample}
             <div class="before"></div>
@@ -40,10 +40,10 @@ var DescriptionCtrl = Class({
             <div class="after"></div>
         {/if}
     </div>
-{/template}
+</template>
 
 
-{export template mainLayout(data, playground)}
+<export template mainLayout(data, playground)>
     <#sampleList data="{data}" playground="{playground}"/>
 
     <div class="hsp-sample {{'hsp-sample-full': data.navCollapsed}}" onclick="{hideNavHover(event, data)}">
@@ -67,7 +67,7 @@ var DescriptionCtrl = Class({
             </div>
         </div>
     </div>
-{/template}
+</template>
 
 function splitterReleased(position, data, playground) {
     data.splitterPos = position + "px";
@@ -101,7 +101,7 @@ function hideNavHover(event, data) {
     }
 }
 
-{template sampleList(data, playground)}
+<template sampleList(data, playground)>
     <div class="samples-list {{'samples-list-collapsed': data.navCollapsed}}"
         onclick="{hideNavHover(event, data)}">
 
@@ -127,9 +127,9 @@ function hideNavHover(event, data) {
             {/foreach}
         </div>
     </div>
-{/template}
+</template>
 
-{export template errorList(errors)}
+<export template errorList(errors)>
     {if errors && errors.length}
         <div class="errorlist">
             <ul>
@@ -152,4 +152,4 @@ function hideNavHover(event, data) {
             </ul>
         </div>
     {/if}
-{/template}
+</template>

--- a/docs/playground/splitter.hsp
+++ b/docs/playground/splitter.hsp
@@ -73,9 +73,9 @@ var SplitterCtrl = Class({
 });
 
 
-{template splitter using controller:SplitterCtrl}
+<template splitter using controller:SplitterCtrl>
     <div class="splitter" onmousedown="{controller.onMouseDown(event)}"></div>
     <div class="splitter-proxy {{'splitter-proxy-hidden': !controller.active}}"></div>
-{/template}
+</template>
 
 module.exports = splitter;

--- a/docs/samples/clickhandler/clickhandler.hsp
+++ b/docs/samples/clickhandler/clickhandler.hsp
@@ -1,11 +1,11 @@
 var msg={text:""}, count=-1;
 
-{template message(msg)}
+<template message(msg)>
     <div title="click me!" onclick="{changeMessage()}" class="noTextSelection">
         {if msg.isWarning}<div class="warning">WARNING:&nbsp;</div>{/if}
         {msg.text}
     </div>
-{/template}
+</template>
 
 function changeMessage() {
     count++;

--- a/docs/samples/clock/clock.hsp
+++ b/docs/samples/clock/clock.hsp
@@ -42,7 +42,7 @@ var ClockController=klass({
 	}
 });
 
-{template clock using c:ClockController}
+<template clock using c:ClockController>
 	// example from http://www.ractivejs.org/examples/clock/
 	<div class="square">
 		<svg viewBox="0 0 100 100">
@@ -67,13 +67,13 @@ var ClockController=klass({
 		</svg>
 		<div class="city">{c.cityName}</div>
 	</div>
-{/template}
+</template>
 
-{template demo}
+<template demo>
 	<#clock city="SFO"/>
 	<#clock city="PAR"/>
 	<#clock city="TYO"/>
-{/template}
+</template>
 
 // Needed by the playground application.
 // Update it, but do not remove it!

--- a/docs/samples/component1/timer.hsp
+++ b/docs/samples/component1/timer.hsp
@@ -17,15 +17,15 @@ var Timer=klass({
     }
 });
 
-{template timer using t:Timer}
+<template timer using t:Timer>
     Elapsed time: {t.secondsElapsed}s
-{/template}
+</template>
 
-{template test}
+<template test>
   Sample showing two timer instances with different init values:<br/>
   <#timer/> <br/>
   <#timer initvalue="10"/>
-{/template}
+</template>
 
 
 // Needed by the playground application.

--- a/docs/samples/component2/nbrfield.hsp
+++ b/docs/samples/component2/nbrfield.hsp
@@ -76,17 +76,17 @@ function getNumber(s) {
     class="nbrfield {{'error': !c.isValid}}"/>
     <button onclick="{c.resetField()}">reset</button>
   </span>
-{/template}
+</template>
 
 // component usage
-{template test(d)}
+<template test(d)>
   Component #1: <#nbrfield value="{d.value1}" min="-10" max="1000"/><br/>
   Value in the data model: <span class="textValue">{d.value1}</span>
   (min:-10 / max:1000 / default:0)
   <hr/>
   Component #2: <#nbrfield value="{d.value2}"/><br/>
   Value in the data model: <span class="textValue">{d.value2}</span>
-{/template}
+</template>
 
 
 // Needed by the playground application.

--- a/docs/samples/component3/pagination.hsp
+++ b/docs/samples/component3/pagination.hsp
@@ -43,7 +43,7 @@ var Pagination=klass({
     }
 });
 
-{template pagination using p:Pagination}
+<template pagination using p:Pagination>
     <ul class="pagination">
         <li class="{{'disabled':p.activepage===0}}">
             <a href="javascript:void(0)" onclick="{p.selectPage(p.activepage-1)}">Previous</a>
@@ -57,9 +57,9 @@ var Pagination=klass({
             <a href="javascript:void(0)" onclick="{p.selectPage(p.activepage+1)}">Next</a>
         </li>
     </ul>
-{/template}
+</template>
 
-{template paginationTest(model)}
+<template paginationTest(model)>
   <div class="section3">
     <label class="fieldlabel">Active page: </label><input type="number"  model="{model.active}"/><br/>
     <label class="fieldlabel">Collection size: </label><input type="number"  model="{model.collectionSize}"/><br/>
@@ -69,7 +69,7 @@ var Pagination=klass({
   <#pagination activepage="{model.active}" collectionsize="{model.collectionSize}"
     pagesize="{model.pageSize}" onpageselect="{updateSelection(event.pageNumber)}"/>
 
-{/template}
+</template>
 
 var model = {
     active: 4,

--- a/docs/samples/conditions/conditions.hsp
+++ b/docs/samples/conditions/conditions.hsp
@@ -1,7 +1,7 @@
 var klass=require("hsp/klass");
 
 // nt is an instance of NumberTester
-{template test(nt)}
+<template test(nt)>
     <div>
         Number: <span class="textvalue">{nt.number}</span>
         {if nt.number==0}
@@ -21,7 +21,7 @@ var klass=require("hsp/klass");
         <a href="javascript:void(0)" onclick="{nt.increment(1)}">Increment Number</a> -
         <a href="javascript:void(0)" onclick="{nt.increment(-1)}">Decrement Number</a>
     </div>
-{/template}
+</template>
 
 // klass is a little utility to create a JS object constructor
 // from a simple JSON structure - main goals are to

--- a/docs/samples/cssclass/cssclass.hsp
+++ b/docs/samples/cssclass/cssclass.hsp
@@ -1,4 +1,4 @@
-{template message(msg)}
+<template message(msg)>
     // onselectstart: prevent double-click selection on a elements
     <div onselectstart="return false">
         <a href="javascript:void(0)" onclick="{toggleUrgency()}">Change Urgency</a> -
@@ -11,7 +11,7 @@
             Class value: "msg {msg.category} {msg.urgency ? 'urgent' : ''}"
         </div>
     </div>
-{/template}
+</template>
 
 var msg={
     text:"Hello World",

--- a/docs/samples/dynpath/dynpath.hsp
+++ b/docs/samples/dynpath/dynpath.hsp
@@ -1,4 +1,4 @@
-{template grid(data)}
+<template grid(data)>
     <div>
         {foreach idx in data.rows}
             <div>
@@ -16,7 +16,7 @@
     <a href="javascript:void(0)" onclick="{update()}">Update columns B&C</a>
     &nbsp;-&nbsp;
     <a href="javascript:void(0)" onclick="{swapC()}">Show/Hide columns C</a>
-{/template}
+</template>
 
 // create dummy data
 var list=[], count=5;

--- a/docs/samples/dyntemplates/dyntemplates.hsp
+++ b/docs/samples/dyntemplates/dyntemplates.hsp
@@ -1,19 +1,19 @@
-{template test(ctxt)}
+<template test(ctxt)>
   <div><a href="javascript:void(0)" onclick="{swapTemplate()}">Change template</a></div>
   <#ctxt.view ctxt="{ctxt}"/>
-{/template}
+</template>
 
-{template tplA(ctxt)}
+<template tplA(ctxt)>
   <div class="msg">
     A: {ctxt.msg}
   </div>
-{/template}
+</template>
 
-{template tplB(ctxt)}
+<template tplB(ctxt)>
   <div class="msg">
     B: {ctxt.msg2}
   </div>
-{/template}
+</template>
 
 var model={
     view: tplA,

--- a/docs/samples/gestures/gestures.hsp
+++ b/docs/samples/gestures/gestures.hsp
@@ -1,6 +1,6 @@
 require('hsp/gestures/index').register();
 
-{template gestures(msgList)}
+<template gestures(msgList)>
     <div class="touchboard" style="height:200px; background: #27AAFC;text-align:center;"
     	ontap="{addMsg(event)}" ontapstart="{addMsg(event)}" ontapcancel="{addMsg(event)}"
         onlongpress="{addMsg(event)}" onlongpressstart="{addMsg(event)}" onlongpresscancel="{addMsg(event)}"
@@ -17,7 +17,7 @@ require('hsp/gestures/index').register();
     		<div>{msg}</div>
     	{/foreach}
     </div>
-{/template}
+</template>
 
 var eventLog = [];
 

--- a/docs/samples/global/global.hsp
+++ b/docs/samples/global/global.hsp
@@ -1,23 +1,23 @@
 var hsp=require("hsp/rt");
 
-{template item(text,value)}
+<template item(text,value)>
     {if value}
         <div>
             <div class="label">{text}</div>
             <div class="value">{value}</div>
         </div>
     {/if}
-{/template}
+</template>
 
 hsp.global.label=item;
 hsp.global.ln={personDetails:"Person details"};
 
-{template test(person)}
+<template test(person)>
     <div class="global" title="{ln.personDetails}">
         <#label text="First Name: " value="{person.firstName}"/>
         <#label text="Last Name: "  value="{person.lastName}"/>
     </div>
-{/template}
+</template>
 
 // Needed by the playground application.
 // Update it, but do not remove it!

--- a/docs/samples/helloworld/hello.hsp
+++ b/docs/samples/helloworld/hello.hsp
@@ -1,9 +1,9 @@
 // edit me!
-{template hello(name)}
+<template hello(name)>
     <div class="msg">
         Hello {name}!
     </div>
-{/template}
+</template>
 
 // Needed by the playground application.
 // Update it, but do not remove it!

--- a/docs/samples/inputsample/inputsample.hsp
+++ b/docs/samples/inputsample/inputsample.hsp
@@ -1,4 +1,4 @@
-{template inputSample(data)}
+<template inputSample(data)>
     <div class="info2">All the following inputs are synchronized:</div>
     <div class="section">
         Comment #1: <input type="text" value="{data.comment}"/><br/>
@@ -29,7 +29,7 @@
         <input type="{data.dtype}" value="{data.comment}" style="width:100px"/> -
         change type: <input type="text" value="{data.dtype}" style="width:100px"/>
     </div>
-{/template}
+</template>
 
 var d={comment:"edit me!", isChecked:false, selection:"B", dtype:"text"}
 

--- a/docs/samples/let/let.hsp
+++ b/docs/samples/let/let.hsp
@@ -1,4 +1,4 @@
-{template test(m)}
+<template test(m)>
   {let p1=m.part1, m21=m.part2.part21.msg+"!"}
   <div>
     {let p11=p1.part11}
@@ -11,7 +11,7 @@
     {/if}
   </div>
   <a href="javascript:void(0)" onclick="{updateModel()}">Change Model</a>
-{/template}
+</template>
 
 var model={
   part1:{

--- a/docs/samples/list1/list.hsp
+++ b/docs/samples/list1/list.hsp
@@ -14,7 +14,7 @@ var ListController = klass({
 });
 
 // simple list template
-{template list using lc:ListController}
+<template list using lc:ListController>
   // content is the list of attribute sub-elements
   <div class="list {lc.class}">
     {if lc.head}
@@ -34,10 +34,10 @@ var ListController = klass({
         </ul>
     {/if}
   </div>
-{/template}
+</template>
 
 // test template
-{template test(d)}
+<template test(d)>
   <#list head="Static list" class="listcpt">
     <@option>First {d.itemName}</@option>
     <@option>Second {d.itemName}</@option>
@@ -58,7 +58,7 @@ var ListController = klass({
       <@option>{idx+1}. {itm}</@option>
     {/foreach}
   </#list>
-{/template}
+</template>
 
 var count=0, model={
   itemName: "item",

--- a/docs/samples/list2/list.hsp
+++ b/docs/samples/list2/list.hsp
@@ -36,7 +36,7 @@ var ListCtrl = klass({
 });
 
 // simple list template
-{template list using lc:ListCtrl}
+<template list using lc:ListCtrl>
   // content is the list of attribute sub-elements
   <div class="list {lc.class}">
     {if lc.head}
@@ -58,10 +58,10 @@ var ListCtrl = klass({
       </ul>
     {/if}
   </div>
-{/template}
+</template>
 
 // test template
-{template test(d)}
+<template test(d)>
   Click on an item to select it:
 
   <#list head="Static list" class="listcpt" onselect="{showSelection(event.value)}">
@@ -81,7 +81,7 @@ var ListCtrl = klass({
   </#list>
 
   {if d.selectedItem!==null}Last selected value: {d.selectedItem}{/if}
-{/template}
+</template>
 
 var count=0, model={
   itemName: "item",

--- a/docs/samples/listsorting/list.hsp
+++ b/docs/samples/listsorting/list.hsp
@@ -1,4 +1,4 @@
-{template list(persons)}
+<template list(persons)>
     <div onselectstart="return false">
         <div class="msg">
             <span class="info">
@@ -24,7 +24,7 @@
             <a onclick="{nameSorter.nextState()}">Change sort order</a>
         </div>
     </div>
-{/template}
+</template>
 
 var people = [
     {name:"Homer", age:38},

--- a/docs/samples/listupdate/list.hsp
+++ b/docs/samples/listupdate/list.hsp
@@ -1,4 +1,4 @@
-{template list(persons)}
+<template list(persons)>
     <div> 
         <div class="msg">
             <a href="javascript:void(0)" onclick="{addElement()}">Add element</a> -
@@ -18,7 +18,7 @@
     <div class="msg">
         Number of people in the list: {persons.length}
     </div>
-{/template}
+</template>
 
 var persons=[
     {firstName:"Homer",lastName:"Simpsons"},

--- a/docs/samples/logs/logs.hsp
+++ b/docs/samples/logs/logs.hsp
@@ -1,6 +1,6 @@
 var log=require("hsp/rt/log");
 
-{template test(cities, logs)}
+<template test(cities, logs)>
   {log "top-level:",scope}
   <a href="javascript:void(0)" onclick="{increaseList()}">Increase list</a> -
   <a href="javascript:void(0)" onclick="{decreaseList()}">Decrease list</a> -
@@ -22,7 +22,7 @@ var log=require("hsp/rt/log");
       {/foreach}
     </ul>
   </div>
-{/template}
+</template>
 
 // register new logger
 var logs=[];

--- a/docs/samples/modifiers/modifiers.hsp
+++ b/docs/samples/modifiers/modifiers.hsp
@@ -37,7 +37,7 @@ var Sorter=klass({
     }
 })
 
-{template sample(d)}
+<template sample(d)>
     <div class="section2">
         Message in capital letters:
         <span class="textvalue">{d.msg|changeCase:"upper"}</span><br/>
@@ -58,7 +58,7 @@ var Sorter=klass({
             Toggle sort order (current: {sortByName.ascending? "ascending" : "descending"})
         </a>
     </div>
-{/template}
+</template>
 
 var data={
     msg:"Hello Simpsons!",

--- a/docs/samples/panel/panel.hsp
+++ b/docs/samples/panel/panel.hsp
@@ -8,7 +8,7 @@ var PanelController = klass({
 });
 
 // sample panel template
-{template panel using c:PanelController}
+<template panel using c:PanelController>
   <div class="panel">
     {if c.head}
       <div class="head"> <#c.head/> </div>
@@ -17,9 +17,9 @@ var PanelController = klass({
       <#c.body/>
     </div>
   </div>
-{/template}
+</template>
 
-{template test(m)}
+<template test(m)>
   <#panel body="Panel A (headless): {m.text}"/>
 
   <#panel head="Panel B ({m.text}!)">
@@ -30,7 +30,7 @@ var PanelController = klass({
     <@head>Panel C: <a href="javascript:void(0)" onclick="{update(10)}">Update model</a></@head>
     <@body>{m.text}! <a href="javascript:void(0)" onclick="{update(100)}">Update model</a></@body>
   </#panel>
-{/template}
+</template>
 
 var model={text:"Hello World"}, count=0;
 

--- a/docs/samples/simplelist/simplelist.hsp
+++ b/docs/samples/simplelist/simplelist.hsp
@@ -1,4 +1,4 @@
-{template people(d)}
+<template people(d)>
     <div class="msg">Click on a person to see more details:</div>
     <ul class="noTextSelection">
     {foreach p in d.people}
@@ -12,7 +12,7 @@
     <div class="msg">
         Number of people in the list: {d.people.length}
     </div>
-{/template}
+</template>
 
 function toggleDetails(person) {
     person.showdetails = !person.showdetails;

--- a/docs/samples/subtemplates/subtemplates.hsp
+++ b/docs/samples/subtemplates/subtemplates.hsp
@@ -7,23 +7,23 @@
             {if !p_islast} <hr/> {/if}
         {/foreach}
     </div>
-{/template}
+</template>
 
 {export template personDescription(person)}
     <div class="person">
         <#item label="First Name: " value="{person.firstName}"/>
         <#item label="Last Name: " value="{person.lastName}"/>
     </div>
-{/template}
+</template>
 
-{template item(label,value)}
+<template item(label,value)>
     {if value}
         <div>
             <div class="label">{label}</div>
             <div class="value">{value}</div>
         </div>
     {/if}
-{/template}
+</template>
 
 var persons=[
     {firstName:"Homer",lastName:"Simpsons"},

--- a/docs/samples/tabbar/tabbar.hsp
+++ b/docs/samples/tabbar/tabbar.hsp
@@ -43,7 +43,7 @@ var TabBarCtrl = klass({
     }
 });
 
-{template tabbar using ctrl:TabBarCtrl}
+<template tabbar using ctrl:TabBarCtrl>
   <div class="x-tabbar">
     <nav class="x-tabs">
         {foreach idx, tab in ctrl.content}
@@ -65,9 +65,9 @@ var TabBarCtrl = klass({
         <#ctrl.selectedTab.body />
     </div>
   </div>
-{/template}
+</template>
 
-{template test}
+<template test>
   {let showSubTabs=false, selection1=0, selection2=0}
   <#tabbar selection="{selection1}">
     <@tab label="Tab A">
@@ -87,7 +87,7 @@ var TabBarCtrl = klass({
     <input id="cb1" type="checkbox" model="{showSubTabs}"/>
     Show nested tabs in tab A
   </label>
-{/template}
+</template>
 
 // Needed by the playground application.
 // Update it, but do not remove it!

--- a/docs/samples/textarea/textarea.hsp
+++ b/docs/samples/textarea/textarea.hsp
@@ -1,4 +1,4 @@
-{template sample(data)}
+<template sample(data)>
     <div class="info2">The following textarea elements are synchronized:</div>
     <div class="section">
         <div>Text #1:</div>
@@ -9,7 +9,7 @@
         <textarea rows="4" cols="40"  model="{data.text}"/>
     </div>
     <a href="javascript:void(0)" onclick="{changeText(data)}">Change text</a>
-{/template}
+</template>
 
 var d={
     // Frog by Donna Shepherd

--- a/docs/samples/thirdpartycpts/chart.hsp
+++ b/docs/samples/thirdpartycpts/chart.hsp
@@ -36,11 +36,11 @@ var ChartCpt=klass({
   }
 });
 
-{template chart using c:ChartCpt}
+<template chart using c:ChartCpt>
   <canvas width="{c.width}" height="{c.height}"></canvas>
-{/template}
+</template>
 
-{template test(data)}
+<template test(data)>
   {let datasets=(data.ds=="d1")? d1 : d2}
   <#chart width="380" height="220" type="{data.type}" labels="{labels}" datasets="{datasets}"/>
   <div style="padding:15 0 0 30">
@@ -53,7 +53,7 @@ var ChartCpt=klass({
     <label for="rb3"><input id="rb3" type="radio" model="{data.ds}" value="d1"/> d1</label>&nbsp;
     <label for="rb4"><input id="rb4" type="radio" model="{data.ds}" value="d2"/> d2</label>
   </div>
-{/template}
+</template>
 
 
 // Needed by the playground application.

--- a/docs/samples/timer/timer.hsp
+++ b/docs/samples/timer/timer.hsp
@@ -1,8 +1,8 @@
 var klass=require("hsp/klass");
 
-{template elapsedTime(timer)}
+<template elapsedTime(timer)>
     Seconds Elapsed: {timer.secondsElapsed}
-{/template}
+</template>
 
 // klass is a little utility to create a JS object constructor
 // from a simple JSON structure - main goals are to

--- a/docs/samples/todolist/todolist.hsp
+++ b/docs/samples/todolist/todolist.hsp
@@ -1,6 +1,6 @@
 var klass=require("hsp/klass");
 
-{template todolist(todo)}
+<template todolist(todo)>
     <div>
         <h3>TODO...</h3>
         <ul>
@@ -13,7 +13,7 @@ var klass=require("hsp/klass");
             <button>{'Add #' + (todo.data.items.length + 1)}</button>
         </form>
     </div>
-{/template}
+</template>
 
 // todo controller
 var TodoCtl=klass({

--- a/docs/start/explained/index.md
+++ b/docs/start/explained/index.md
@@ -30,12 +30,12 @@ First, let's create a simple HSP file and a controller:
 ````
 var HelloCtrl = require("./HelloCtrl");
 
-{template Hello using ctrl:HelloCtrl}
+<template Hello using ctrl:HelloCtrl>
    <p>Hello, {ctrl.name}!</p>
 
    <input model="{ctrl.name}">
    <button onclick="{ctrl.clear()}">Clear</button>
-{/template}
+</template>
 
 module.exports = Hello;
 ```

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -26,12 +26,12 @@ First, let's create a simple Hashspace template `Hello` and a controller:
 ````
 var HelloCtrl = require("./HelloCtrl");
 
-{template Hello using ctrl:HelloCtrl}
+<template Hello using ctrl:HelloCtrl>
    <p>Hello, {ctrl.name}!</p>
 
    <input model="{ctrl.name}">
    <button onclick="{ctrl.clear()}">Clear</button>
-{/template}
+</template>
 
 module.exports = Hello;
 ```

--- a/hsp/compiler/README.md
+++ b/hsp/compiler/README.md
@@ -5,9 +5,9 @@
 In hashspace, compiling means transforming a template from the specific syntax into a javascript string.
 For example, this template
 ```
-{template hello(person)}
+<template hello(person)>
     Hello {person.name}!
-{/template}
+</template>
 ```
 becomes `n.$text({e1:[1,2,"person","name"]},["Hello ",1,"!"])`
 
@@ -21,9 +21,9 @@ The compilation is in fact a 3 steps process:
 ### Sample ###
 Initial template:
 ```
-{template hello(person)}
+<template hello(person)>
     Hello {person.name}!
-{/template}
+</template>
 ```
 
 Parser output:

--- a/hsp/compiler/parser/README.md
+++ b/hsp/compiler/parser/README.md
@@ -9,11 +9,11 @@ The grammar is stored in the `hspblocks.pegjs` file, which is itself compiled in
 ## Input ##
 The hashspace template source code, e.g.:
 ```
-{template test(person)}
+<template test(person)>
     <div title="Some text" id="{person.id}" class="{person.gender} {person.category}">
         Hello {person.name}!
     </div>
-{/template}
+</template>
 ```
 
 ## Output ##

--- a/test/compiler/errsamples/block.txt
+++ b/test/compiler/errsamples/block.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     {foo bar} Hello World!
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/component1.txt
+++ b/test/compiler/errsamples/component1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <#lib.panel title="Some text">
         foo bar
     </#lib.pan>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/component2.txt
+++ b/test/compiler/errsamples/component2.txt
@@ -1,11 +1,11 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <#lib.panel title="Some text">
       <@lib.head>
         foo
       </@lib.head>
     </#lib.panel>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/component3.txt
+++ b/test/compiler/errsamples/component3.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template eat()}
+<template eat()>
     <#fruit>Banana</fruit>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/element1.txt
+++ b/test/compiler/errsamples/element1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <div title="Some text" id="{person.id}" class="{person.gender} {person.category}">
         <span>Hello {person.name}!
     </div>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/element2.txt
+++ b/test/compiler/errsamples/element2.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <div title="Some text" id="{person.id}" class="{person.gender} {person.category}">
         <span>Hello {person.name}!</span>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/element3.txt
+++ b/test/compiler/errsamples/element3.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <div title="Some text">
         foo bar
     </di>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/element4.txt
+++ b/test/compiler/errsamples/element4.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <div title="Some text class="foo">
         foo bar
     </div>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/element5.txt
+++ b/test/compiler/errsamples/element5.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <div title="blah" 
         foo bar
     </div>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/element6.txt
+++ b/test/compiler/errsamples/element6.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <img onclick="{doClick('blah',event,)}"/>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/element7.txt
+++ b/test/compiler/errsamples/element7.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <img onclick="foo{doClick('blah',event,)}bar"/>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/element8.txt
+++ b/test/compiler/errsamples/element8.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     <img onclick="{123}"/>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/foreach1.txt
+++ b/test/compiler/errsamples/foreach1.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template test(things)}
+<template test(things)>
   Foreach test:
   {foreach (thing inm things)} - {thing} - {/foreach}
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/foreach2.txt
+++ b/test/compiler/errsamples/foreach2.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template test(things)}
+<template test(things)>
   Foreach test:
   {foreach (thing in things)} - {thing} - {/forach}
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/foreach3.txt
+++ b/test/compiler/errsamples/foreach3.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template test(things)}
+<template test(things)>
   Foreach test:
   {thing} - {/foreach}
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/htmlEntities.txt
+++ b/test/compiler/errsamples/htmlEntities.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test()}
+<template test()>
 &invalid;
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/if1.txt
+++ b/test/compiler/errsamples/if1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     {if (person.isAdult}
         Hello
     {/if}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/if2.txt
+++ b/test/compiler/errsamples/if2.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     {if person.isAdult}
         Hello
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/if3.txt
+++ b/test/compiler/errsamples/if3.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     {if person.isAdult}
         Hello
     {else}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/if4.txt
+++ b/test/compiler/errsamples/if4.txt
@@ -1,11 +1,11 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     {if person.isAdult}
         blah
     {else if person.isMinor/}
         blah
     {/if}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/if5.txt
+++ b/test/compiler/errsamples/if5.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     blah
     {/if}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/if6.txt
+++ b/test/compiler/errsamples/if6.txt
@@ -1,10 +1,10 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     blah
     {else}
         blah
     {/if}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/if7.txt
+++ b/test/compiler/errsamples/if7.txt
@@ -1,10 +1,10 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     blah
     {else if foo}
         blah
     {/if}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/insert.txt
+++ b/test/compiler/errsamples/insert.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
     foo
     {content("First Name", person.firstName}
     bar
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/jsexpression1.txt
+++ b/test/compiler/errsamples/jsexpression1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(value)}
+<template test(value)>
     {if !(++value)}
         Hello
     {/if}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/jsexpression2.txt
+++ b/test/compiler/errsamples/jsexpression2.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(x,y)}
+<template test(x,y)>
     {if !(x++ && y--)}
         Hello
     {/if}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/jsexpression3.txt
+++ b/test/compiler/errsamples/jsexpression3.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
   {person.name|foo:}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/jsexpression4.txt
+++ b/test/compiler/errsamples/jsexpression4.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
   {person.name|}
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/let1.txt
+++ b/test/compiler/errsamples/let1.txt
@@ -1,12 +1,12 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
   // This is OK
   {let p=person}
   <div class="foo">
     This is KO
     {let p2=person}
   </div>
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/let2.txt
+++ b/test/compiler/errsamples/let2.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
   <div class="foo">
     {let p=person} // OK
     <span>
@@ -15,7 +15,7 @@
     </span>
   </div>
   {let p=person} // KO
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/let3.txt
+++ b/test/compiler/errsamples/let3.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
   <#x.mycpt class="foo">
     {let p=person} // OK
     {foreach n in p.names}
@@ -16,7 +16,7 @@
       {let p=person} // KO
     </@body>
   </#x.cpt2>
-{/template}
+</template>
 
 ##### Error:
 [

--- a/test/compiler/errsamples/mixed1.txt
+++ b/test/compiler/errsamples/mixed1.txt
@@ -4,11 +4,11 @@ function foo() {
     return x;
 }
 
-{template test(person)}
+<template test(person)>
     <div title="Some text" id="{person.id}" class="{person.gender} {person.category}">
         <span>Hello {person.name}!</span>
     </div>
-{/template}
+</template>
 
 function bar() {
     foo({blah:"hello",});

--- a/test/compiler/errsamples/mixed2.txt
+++ b/test/compiler/errsamples/mixed2.txt
@@ -4,10 +4,10 @@ function foo() {
     return x;
 }
 
-{template test(person)}
+<template test(person)>
     <div title="Some text" id="{person.id}" class="{person.gender} {person.category}">
         <span>Hello {person.name}!</span>
     </div>
-{/template}
+</template>
 
 ##### Errors:

--- a/test/compiler/errsamples/mixed3.txt
+++ b/test/compiler/errsamples/mixed3.txt
@@ -1,10 +1,10 @@
 ##### Template:
 // line 1
-{template test(person)}
+<template test(person)>
     <div title="Some text" id="{person.id}" class="{person.gender} {person.category}">
         <span>Hello {person.name}!</span>
     </div>
-{/template}
+</template>
 // line 7
 .var foo=42;
 

--- a/test/compiler/errsamples/mixed4.txt
+++ b/test/compiler/errsamples/mixed4.txt
@@ -1,15 +1,15 @@
 ##### Template:
 // line 1
-{template test(person)}
+<template test(person)>
     <div title="Some text" id="{person.id}" class="{person.gender} {person.category}">
         <span>Hello {person.name}!</span>
     </div>
-{/template}
+</template>
 // line 7
 var foo=42;
-{template bar}
+<template bar>
     Hello
-{/template}
+</template>
 // line 12
 .
 

--- a/test/compiler/errsamples/template1.txt
+++ b/test/compiler/errsamples/template1.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello foo}
+<template hello foo>
     {foo.bar} Hello World!
-{/template}
+</template>
 
 ##### Errors:
 [
@@ -9,6 +9,6 @@
     "description": "Invalid template declaration",
     "line": 1,
     "column": 1,
-    "code": "{template hello foo}"
+    "code": "<template hello foo>"
   }
 ]

--- a/test/compiler/errsamples/template2.txt
+++ b/test/compiler/errsamples/template2.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template hello(foo)}
+<template hello(foo)>
     {foo.bar} Hello World!
 
 ##### Errors:

--- a/test/compiler/errsamples/template3.txt
+++ b/test/compiler/errsamples/template3.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template hello(foo)}
+<template hello(foo)>
     {foo.bar} Hello World!
 # blahblah foo
 

--- a/test/compiler/errsamples/template4.txt
+++ b/test/compiler/errsamples/template4.txt
@@ -1,9 +1,9 @@
 ##### Template:
-# espor template hello()
+<espor template hello()>
     Hello World!
-# blahblah foo
+<blahblah foo>
 
-# /templte
+</templte>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/template5.txt
+++ b/test/compiler/errsamples/template5.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(event)}
+<template test(event)>
     Hello World!
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/template6.txt
+++ b/test/compiler/errsamples/template6.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(scope)}
+<template test(scope)>
     Hello World!
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/template7.txt
+++ b/test/compiler/errsamples/template7.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(foo,_bar)}
+<template test(foo,_bar)>
     Hello World! {_bar}
-{/template}
+</template>
 
 ##### Errors:
 [
@@ -9,6 +9,6 @@
     "description": "Invalid template declaration",
     "line": 1,
     "column": 1,
-    "code": "{template test (foo,_bar)}"
+    "code": "<template test (foo,_bar)>"
   }
 ]

--- a/test/compiler/errsamples/template8.txt
+++ b/test/compiler/errsamples/template8.txt
@@ -1,7 +1,7 @@
 ##### Template:
-# template test(foo,_bar)}
+<template test(foo,_bar)}
     blah
-{/template}
+</template>
 
 ##### Errors:
 [
@@ -9,6 +9,6 @@
     "description": "Invalid template declaration",
     "line": 1,
     "column": 1,
-    "code": "# template test (foo,_bar)}"
+    "code": "<template test (foo,_bar)}"
   }
 ]

--- a/test/compiler/errsamples/template9.txt
+++ b/test/compiler/errsamples/template9.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(foo,_bar)
+<template test(foo,_bar)
     blah
-{/template}
+</template>
 
 ##### Errors:
 [
@@ -9,6 +9,6 @@
     "description": "Invalid template declaration",
     "line": 1,
     "column": 1,
-    "code": "{template test (foo,_bar)"
+    "code": "<template test (foo,_bar)"
   }
 ]

--- a/test/compiler/errsamples/text1.txt
+++ b/test/compiler/errsamples/text1.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     Hello {person.name,}!
-{/template}
+</template>
 
 ##### Errors:
 [ { 

--- a/test/compiler/errsamples/text2.txt
+++ b/test/compiler/errsamples/text2.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     {foo bar} Hello World!
-{/template}
+</template>
 
 ##### Errors:
 [{

--- a/test/compiler/errsamples/text3.txt
+++ b/test/compiler/errsamples/text3.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
     {foo[2].bar["hello"]]} Hello World!
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/errsamples/voidelement.txt
+++ b/test/compiler/errsamples/voidelement.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test}
+<template test>
     Hello<br>World</br>
-{/template}
+</template>
 
 ##### Errors:
 [

--- a/test/compiler/samples/class1.txt
+++ b/test/compiler/samples/class1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(msg)}
+<template test(msg)>
 	<div class="{{'warning':msg.urgent==='1'}}">
     Hello World
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/class2.txt
+++ b/test/compiler/samples/class2.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(msg)}
+<template test(msg)>
 	<div class="{{'warning':msg.urgent}} {msg.category}">
     Hello World
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/class3.txt
+++ b/test/compiler/samples/class3.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(msg)}
+<template test(msg)>
 	<div class="{msg.category} {{'warning':msg.urgent}} msg">
     Hello World
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/class4.txt
+++ b/test/compiler/samples/class4.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(msg)}
+<template test(msg)>
 	<div class="{{}}">
     Hello World
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/class5.txt
+++ b/test/compiler/samples/class5.txt
@@ -1,12 +1,12 @@
 ##### Template:
-{template test(msg)}
+<template test(msg)>
   <div class="one {{'two':msg.isTrue}}">
     foo
   </div>
   <div class="one {{'two':msg.isTrue}}">
     foo
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/comment.txt
+++ b/test/compiler/samples/comment.txt
@@ -1,16 +1,16 @@
 ##### Template:
-{template hello(world)}
+<template hello(world)>
 	Hello // comment 1
 	World!
 	{if (world)} // comment 2
 	   <!-- another comment
 	   on multiple 
 	   lines 
-	   {/template}
+	   </template>
 	   -->
 	   ...
 	{/if}
-{/template}
+</template>
 
 ##### Parsed Tree
 
@@ -27,7 +27,7 @@
       {"type": "text","value": " "},
       {"type": "comment","value": " comment 2"},
       {"type": "text","value": " "},
-      {"type": "comment","value": " another comment\n\t   on multiple \n\t   lines \n\t   {/template}\n\t   "},
+      {"type": "comment","value": " another comment\n\t   on multiple \n\t   lines \n\t   </template>\n\t   "},
       {"type": "text","value": " ... "},
       {"type": "endif"}
     ]

--- a/test/compiler/samples/component1.txt
+++ b/test/compiler/samples/component1.txt
@@ -1,10 +1,10 @@
 ##### Template:
 
-{template foo()}
+<template foo()>
   foo
   <#mylib.mycpt att1="foo" att2="bar"/>
   bar
-{/template}
+</template>
 
 ##### Parsed Tree:
 

--- a/test/compiler/samples/component2.txt
+++ b/test/compiler/samples/component2.txt
@@ -1,8 +1,8 @@
 ##### Template:
 
-{template mycomponent using c:foo.ComponentController}
+<template mycomponent using c:foo.ComponentController>
   some text...
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/component3.txt
+++ b/test/compiler/samples/component3.txt
@@ -1,9 +1,9 @@
 ##### Template:
 
-{template nbrfield using c:lib.NbrField}
+<template nbrfield using c:lib.NbrField>
   <input type="text" model="{c.fieldValue}" class="nbrfield {{'error': c.invalidValue, 'mandatory': c.attributes.mandatory}}"/>
   <input type="button" value="..." onclick="{c.resetField()}"/>
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/component4.txt
+++ b/test/compiler/samples/component4.txt
@@ -1,9 +1,9 @@
 ##### Template:
 
-{template test(d)}
+<template test(d)>
   <input type="text" value="{d.value}"/>
   <#lib.nbrfield value="{d.value}" min="-10" max="10" onreset="{notifyReset(123)}"/>
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/component5.txt
+++ b/test/compiler/samples/component5.txt
@@ -1,11 +1,11 @@
 ##### Template:
-{template test()}
+<template test()>
   <#panel>
     <#body class="foo">
       Hello World!
     </#body>
   </#panel>
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/component6.txt
+++ b/test/compiler/samples/component6.txt
@@ -1,11 +1,11 @@
 ##### Template:
-{template test()}
+<template test()>
   <#panel>
     <@body class="foo">
       Hello World!
     </@body>
   </#panel>
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/component7.txt
+++ b/test/compiler/samples/component7.txt
@@ -1,8 +1,8 @@
 ##### Template:
 
-{template test(d)}
+<template test(d)>
   <#lib.nbrfield objliteral="{{value: d.value, min: 10, max: "10", reset: notifyReset(123)}}"/>
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/component8.txt
+++ b/test/compiler/samples/component8.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test using c:Ctrl}
+<template test using c:Ctrl>
    <#c.tpl />
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/element1.txt
+++ b/test/compiler/samples/element1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	<div title="Some text" id="{person.id}" class="{person.gender} {person.category}">
 		Hello {person.name}!
 	</div>
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/element2.txt
+++ b/test/compiler/samples/element2.txt
@@ -1,10 +1,10 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	<div title="Some text">
 		<b>Some text in <span class="test">bold</span></b>
 		<input type="text" value="{person.name}"/>
 	</div>
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/element3.txt
+++ b/test/compiler/samples/element3.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	<div title="">
 		Hello World
 	</div>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/element4.txt
+++ b/test/compiler/samples/element4.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	<input type="text" autocomplete/>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/element5.txt
+++ b/test/compiler/samples/element5.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template filterLink(ds, ctl, label, filterCode)   }
+<template filterLink(ds, ctl, label, filterCode)   >
     <a onclick="{ctl.selectFilter(filterCode)}" title="{label}">
         {label}
     </a>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/evthandler1.txt
+++ b/test/compiler/samples/evthandler1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(path, ctl, person)}
+<template test(path, ctl, person)>
 	<img src="http://someting.com/{path}" onclick="{ctl.handleClick()}"/>
 	<img onclick="{ctl.handleClick(path, person.name, "literal arg", event)}"/>
 	<img onclick="{doClick('blah',event)}"/>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/evthandler2.txt
+++ b/test/compiler/samples/evthandler2.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(path, ctl, person)}
+<template test(path, ctl, person)>
 	<img onclick="{doClick(1)}"/>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/evthandler3.txt
+++ b/test/compiler/samples/evthandler3.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(path, ctl, person)}
+<template test(path, ctl, person)>
 	<img onclick="return false"/>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/foreach1.txt
+++ b/test/compiler/samples/foreach1.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template test(things)}
+<template test(things)>
   Foreach test:
   {foreach (thing in things)} - {thing} - {/foreach}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/foreach2.txt
+++ b/test/compiler/samples/foreach2.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template test(label, passengers)}
+<template test(label, passengers)>
   {foreach k,name in passengers.names}
     {if name_isfirst}
       \<\<
@@ -9,7 +9,7 @@
       >>
     {/if}
   {/foreach}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/foreach3.txt
+++ b/test/compiler/samples/foreach3.txt
@@ -1,11 +1,11 @@
 ##### Template:
-{template test(label, passengers)}
+<template test(label, passengers)>
   <div>
     {foreach k,name in passengers.names}
       x
     {/foreach}
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/foreach4.txt
+++ b/test/compiler/samples/foreach4.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test}
+<template test>
   {foreach itm in items}
     {itm}
   {/foreach}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/htmlEntities.txt
+++ b/test/compiler/samples/htmlEntities.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test()}
+<template test()>
 &amp;&times;
-{/template}
+</template>
 
 ##### Parsed Tree
 [

--- a/test/compiler/samples/if1.txt
+++ b/test/compiler/samples/if1.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template test(value1, value2)}
+<template test(value1, value2)>
    Hello
 
    {if value1} World {/if}
@@ -10,7 +10,7 @@
    		B
    {/if}
 
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/if2.txt
+++ b/test/compiler/samples/if2.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template test(v1, v2)}
+<template test(v1, v2)>
    Hello
    {if v1.isWorld} 
    		{if (v2)}
@@ -9,7 +9,7 @@
    		{/if}
    {/if}
 
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/if3.txt
+++ b/test/compiler/samples/if3.txt
@@ -1,10 +1,10 @@
 ##### Template:
-{template test}
+<template test>
    {if true} Boolean {/if}
    {if 123.4} Number {/if}
    {if ('ok')} String1 {/if}
    {if "o\"k"} String2 {/if}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/if4.txt
+++ b/test/compiler/samples/if4.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template test(x)}
+<template test(x)>
    {if x==1} 
    	one 
    {else if x==2}
@@ -7,7 +7,7 @@
    {else}
    	neither one nor two
    {/if}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/jsexpression1.txt
+++ b/test/compiler/samples/jsexpression1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(value)}
+<template test(value)>
   {if (value === "test" || value===false || value===null || value===123)} 
     World
   {/if}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/jsexpression10.txt
+++ b/test/compiler/samples/jsexpression10.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person,foo,bar)}
+<template hello(person,foo,bar)>
   {person.name[foo[bar+1]]}
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/jsexpression11.txt
+++ b/test/compiler/samples/jsexpression11.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person,foo,bar)}
+<template hello(person,foo,bar)>
   {person[person.name+1].foo + x.y}
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/jsexpression12.txt
+++ b/test/compiler/samples/jsexpression12.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person,bar)}
+<template hello(person,bar)>
   <div title="{person[bar]}" class="{person.foo[1+2].blah}">...</div>
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/jsexpression13.txt
+++ b/test/compiler/samples/jsexpression13.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	{orderBy(person.list,"firstName")}
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/jsexpression14.txt
+++ b/test/compiler/samples/jsexpression14.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
   {person.list|orderBy:"firstName"}
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/jsexpression15.txt
+++ b/test/compiler/samples/jsexpression15.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
   <div title="{foo(bar(person.name+"!",1+2))}">
     hello
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/jsexpression16.txt
+++ b/test/compiler/samples/jsexpression16.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
   <div title="{person.name+"!"|bar:1+2|foo}">
     hello
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/jsexpression17.txt
+++ b/test/compiler/samples/jsexpression17.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
   {if person.name|acceptEmpty}
     hello
   {/if}
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/jsexpression18.txt
+++ b/test/compiler/samples/jsexpression18.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
   {foreach p in person.list|orderBy:"name"}
     {p.name}
   {/foreach}
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/jsexpression19.txt
+++ b/test/compiler/samples/jsexpression19.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
   <div title="{{main : {'value' : {A : 'val A', B : person.name, C: {C1:'val C1', C2:'val C2'}}}}}">Hello</div>
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/jsexpression2.txt
+++ b/test/compiler/samples/jsexpression2.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(value)}
+<template test(value)>
   {if !(value>3)} 
     Hello
   {/if}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/jsexpression3.txt
+++ b/test/compiler/samples/jsexpression3.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(value)}
+<template test(value)>
   {value+2+"a"}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/jsexpression4.txt
+++ b/test/compiler/samples/jsexpression4.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(value)}
+<template test(value)>
   {(value=="a")+2}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/jsexpression5.txt
+++ b/test/compiler/samples/jsexpression5.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template test(value)}
+<template test(value)>
   {(value=="a")? value : (value===3)}
   {value==="W"? "World" : "You"}
-{/template}
+</template>
 
 ##### Parsed Tree
 

--- a/test/compiler/samples/jsexpression6.txt
+++ b/test/compiler/samples/jsexpression6.txt
@@ -1,10 +1,10 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	Before
 	{content1()}
 	{content2("First Name", person.firstName)}
 	After
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/jsexpression7.txt
+++ b/test/compiler/samples/jsexpression7.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	{content1()}
-{/template}
+</template>
 
 ##### Parsed Tree:
 

--- a/test/compiler/samples/jsexpression8.txt
+++ b/test/compiler/samples/jsexpression8.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person,property)}
+<template hello(person,property)>
 	Hello {person[property]}!
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/jsexpression9.txt
+++ b/test/compiler/samples/jsexpression9.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person,property)}
+<template hello(person,property)>
   {person[person.name].foo}
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/let1.txt
+++ b/test/compiler/samples/let1.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template test(value)}
+<template test(value)>
   {let x=value.nbr+3}
-{/template}
+</template>
 
 ##### Parsed Tree
 [

--- a/test/compiler/samples/let2.txt
+++ b/test/compiler/samples/let2.txt
@@ -1,10 +1,10 @@
 ##### Template:
-{template test(value)}
+<template test(value)>
   <div class="foo">
     // Some comment
     {let aVarName = value.nbr, anotherName = blah}
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/let3.txt
+++ b/test/compiler/samples/let3.txt
@@ -1,10 +1,10 @@
 ##### Template:
-{template test(foo)}
+<template test(foo)>
   <div class="foo">
     // Some comment
     {let aVarName = new Foo(), anotherName = new foo.Bar()}
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/let4.txt
+++ b/test/compiler/samples/let4.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(foo)}
+<template test(foo)>
   <div class="foo">
     {let val = new Foo("a",123,blah(1+foo.value))}
   </div>
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/log1.txt
+++ b/test/compiler/samples/log1.txt
@@ -1,9 +1,9 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	Hello
   {log "here", person, scope}
   World
-{/template}
+</template>
 
 ##### Parsed Tree
 [

--- a/test/compiler/samples/log2.txt
+++ b/test/compiler/samples/log2.txt
@@ -1,8 +1,8 @@
 ##### Template:
-{template test(person)}
+<template test(person)>
 	 Advanced log:
    {log 3+4*person.age, person.foo.bar}
-{/template}
+</template>
 
 ##### Parsed Tree
 "skip"

--- a/test/compiler/samples/template1.txt
+++ b/test/compiler/samples/template1.txt
@@ -2,17 +2,17 @@
 var x="text1";
 function func() {var x="text2"};
 
-{template hello1}
+<template hello1>
    Hello World!
-{/template}
+</template>
 
 // comment
 function func2(z) {return z;}
 
-{template hello1bis (arg1, arg2)}
+<template hello1bis (arg1, arg2)>
 	Hello
 	Again!
-{/template}
+</template>
 var z;
 ##### Parsed Tree:
 

--- a/test/compiler/samples/template2.txt
+++ b/test/compiler/samples/template2.txt
@@ -1,8 +1,8 @@
 ##### Template:
 
-{export template hello4()}
+<export template hello4()>
    Hello World!
-{/template}
+</template>
 
 ##### Parsed Tree:
 

--- a/test/compiler/samples/text1.txt
+++ b/test/compiler/samples/text1.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
 	Hello {person.name}!
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/text2.txt
+++ b/test/compiler/samples/text2.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
 	{:person.name}!
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/text3.txt
+++ b/test/compiler/samples/text3.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
 	Hello {person.firstName}{person.lastName}
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/text4.txt
+++ b/test/compiler/samples/text4.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(name)}
+<template hello(name)>
 	Hello {name}!
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/text5.txt
+++ b/test/compiler/samples/text5.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(person)}
+<template hello(person)>
 	<div>{person.name}</div>
-{/template}
+</template>
 
 ##### Parsed Tree:
 [

--- a/test/compiler/samples/text6.txt
+++ b/test/compiler/samples/text6.txt
@@ -1,7 +1,7 @@
 ##### Template:
-{template hello(foo)}
+<template hello(foo)>
 	{foo[2].bar["hello"]} Hello
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/text7.txt
+++ b/test/compiler/samples/text7.txt
@@ -1,8 +1,8 @@
 ##### Template:
 var person = {name : "World"};
-{template hello()}
+<template hello()>
 	Hello {person.name}!
-{/template}
+</template>
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/text8.txt
+++ b/test/compiler/samples/text8.txt
@@ -1,9 +1,9 @@
 ##### Template:
 var nullValue = "null";
 
-{template main()}
+<template main()>
     before-{nullValue}-after
-{/template} 
+</template> 
 
 ##### Parsed Tree:
 "skip"

--- a/test/compiler/samples/voidelement.txt
+++ b/test/compiler/samples/voidelement.txt
@@ -1,5 +1,5 @@
 ##### Template:
-{template test}
+<template test>
     Hello<br>World
     <area>
     <base>
@@ -15,7 +15,7 @@
     <source>
     <track>
     <wbr>
-{/template}
+</template>
 
 ##### Parsed Tree
 [

--- a/test/compiler/tests.js
+++ b/test/compiler/tests.js
@@ -12,17 +12,17 @@ describe('Block Parser: ', function () {
         var s = ['var x="text1";',
                 'function func() {var x="text2"};',
                 '',
-                '{template hello1}',
+                '<template hello1>',
                 '   Hello World!',
-                '{/template}',
+                '</template>',
                 '',
                 '// comment',
                 'function func2(z) {return z;}',
                 '',
-                '{template hello1bis (arg1, arg2)}',
+                '<template hello1bis (arg1, arg2)>',
                 '\tHello',
                 '\tAgain!',
-                '{/template}',
+                '</template>',
                 'var z;'].join("\n");
 
         assert.equal(tpl.replace(/\r/g, ""), s, "sample content");
@@ -102,17 +102,17 @@ describe('Block Parser: ', function () {
         }));
     }
 
-    it('should allow whitespaces before {template}', function(){
+    it('should allow whitespaces before <template>', function(){
       var r = compiler.compile(
-        '\n   {template spacesBefore()}\n' +
-        ' {/template}', "spacesBefore");
+        '\n    <template spacesBefore()>\n' +
+        ' </template>', "spacesBefore");
       assert.equal(r.errors.length, 0, "no compilation error");
     });
 
-    it('should allow whitespaces before {template} when a modifier is present', function(){
+    it('should allow whitespaces before <template> when a modifier is present', function(){
         var r = compiler.compile(
-            '\n   { export  template spacesBefore()}\n' +
-                ' {/template}', "spacesBefore");
+            '\n   < export  template spacesBefore()>\n' +
+                ' </template>', "spacesBefore");
         assert.equal(r.errors.length, 0, "no compilation error");
     });
 
@@ -122,14 +122,14 @@ describe('Block Parser: ', function () {
         }, /The template "\/foo\/bar.js" is empty but content to compile is mandatory./);
 
         assert.throws(function() {
-            compiler.compile('{template foo()}\n{/template}');
+            compiler.compile('<template foo()>\n</template>');
         }, /The template "path" argument is mandatory./);
     });
 
     it('should correctly compile templates with HTML elements containing -', function () {
-        var r =compiler.compile('{template x()}\n' +
+        var r =compiler.compile('<template x()>\n' +
             '<x-div></x-div>\n' +
-            '{/template}', 'x.js');
+            '</template>', 'x.js');
         assert.equal(r.errors.length, 0);
     });
 

--- a/test/gestures/doubleTap.spec.hsp
+++ b/test/gestures/doubleTap.spec.hsp
@@ -21,11 +21,11 @@ require("hsp/gestures/doubleTap").register();
 var fireEvent=require("hsp/utils/eventgenerator").fireEvent,
     touchEventMap = require("hsp/gestures/touchEvent").touchEventMap;
 
-{template test1(ctl)}
+<template test1(ctl)>
     <div title="test1" ondoubletap="{ctl.handleEvent(event)}" ondoubletapstart="{ctl.handleEvent(event)}" ondoubletapcancel="{ctl.handleEvent(event)}">
         Hello!
     </div>
-{/template}
+</template>
 
 describe("DoubleTap gesture", function () {
 

--- a/test/gestures/drag.spec.hsp
+++ b/test/gestures/drag.spec.hsp
@@ -21,11 +21,11 @@ require("hsp/gestures/drag").register();
 var fireEvent=require("hsp/utils/eventgenerator").fireEvent,
     touchEventMap = require("hsp/gestures/touchEvent").touchEventMap;
 
-{template test1(ctl)}
+<template test1(ctl)>
     <div title="test1" ondrag="{ctl.handleEvent(event)}" ondragstart="{ctl.handleEvent(event)}" ondragmove="{ctl.handleEvent(event)}" ondragcancel="{ctl.handleEvent(event)}">
         Hello!
     </div>
-{/template}
+</template>
 
 describe("Drag gesture", function () {
 

--- a/test/gestures/longPress.spec.hsp
+++ b/test/gestures/longPress.spec.hsp
@@ -21,11 +21,11 @@ require("hsp/gestures/longPress").register();
 var fireEvent=require("hsp/utils/eventgenerator").fireEvent,
     touchEventMap = require("hsp/gestures/touchEvent").touchEventMap;
 
-{template test1(ctl)}
+<template test1(ctl)>
     <div title="test1" onlongpress="{ctl.handleEvent(event)}" onlongpressstart="{ctl.handleEvent(event)}" onlongpresscancel="{ctl.handleEvent(event)}">
         Hello!
     </div>
-{/template}
+</template>
 
 describe("LongPress gesture", function () {
     function validate(expected, result) {

--- a/test/gestures/pinch.spec.hsp
+++ b/test/gestures/pinch.spec.hsp
@@ -21,11 +21,11 @@ require("hsp/gestures/pinch").register();
 var fireEvent=require("hsp/utils/eventgenerator").fireEvent,
     touchEventMap = require("hsp/gestures/touchEvent").touchEventMap;
 
-{template test1(ctl)}
+<template test1(ctl)>
     <div title="test1" onpinch="{ctl.handleEvent(event)}" onpinchstart="{ctl.handleEvent(event)}" onpinchmove="{ctl.handleEvent(event)}" onpinchcancel="{ctl.handleEvent(event)}">
         Hello!
     </div>
-{/template}
+</template>
 
 describe("Pinch gesture", function () {
 

--- a/test/gestures/singleTap.spec.hsp
+++ b/test/gestures/singleTap.spec.hsp
@@ -21,11 +21,11 @@ require("hsp/gestures/singleTap").register();
 var fireEvent=require("hsp/utils/eventgenerator").fireEvent,
     touchEventMap = require("hsp/gestures/touchEvent").touchEventMap;
 
-{template test1(ctl)}
+<template test1(ctl)>
     <div title="test1" onsingletap="{ctl.handleEvent(event)}" onsingletapstart="{ctl.handleEvent(event)}" onsingletapcancel="{ctl.handleEvent(event)}">
         Hello!
     </div>
-{/template}
+</template>
 
 describe("SingleTap gesture", function () {
 

--- a/test/gestures/swipe.spec.hsp
+++ b/test/gestures/swipe.spec.hsp
@@ -21,11 +21,11 @@ require("hsp/gestures/swipe").register();
 var fireEvent=require("hsp/utils/eventgenerator").fireEvent,
     touchEventMap = require("hsp/gestures/touchEvent").touchEventMap;
 
-{template test1(ctl)}
+<template test1(ctl)>
     <div title="test1" onswipe="{ctl.handleEvent(event)}" onswipestart="{ctl.handleEvent(event)}" onswipemove="{ctl.handleEvent(event)}" onswipecancel="{ctl.handleEvent(event)}">
         Hello!
     </div>
-{/template}
+</template>
 
 describe("Swipe gesture", function () {
 

--- a/test/gestures/tap.spec.hsp
+++ b/test/gestures/tap.spec.hsp
@@ -21,14 +21,14 @@ require("hsp/gestures/tap").register();
 var fireEvent=require("hsp/utils/eventgenerator").fireEvent,
     touchEventMap = require("hsp/gestures/touchEvent").touchEventMap;
 
-{template test1(ctl)}
+<template test1(ctl)>
     <div title="test1" ontap="{ctl.handleTap(event)}" ontapstart="{ctl.handleTap(event)}" ontapcancel="{ctl.handleTap(event)}">
         Hello!
     </div>
     <div title="test2" ontap="{ctl.handleTap(event)}" ontapstart="{ctl.handleTap(event)}" ontapcancel="{ctl.handleTap(event)}">
         Hello!
     </div>
-{/template}
+</template>
 
 describe("Tap gesture", function () {
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -16,7 +16,7 @@ var codeGenerator = require("../../compiler/codeGenerator");
  */
 exports.parse = function (template) {
     try {
-        var parsedContent = parser.parse(["{template test()}", template, "{/template}"].join("\n"));
+        var parsedContent = parser.parse(["<template test()>", template, "</template>"].join("\n"));
 
         // there's only one template
         return parseTree.create(parsedContent[0]);

--- a/test/rt/attributes/class.spec.hsp
+++ b/test/rt/attributes/class.spec.hsp
@@ -16,13 +16,13 @@
 var hsp = require("hsp/rt");
 var $set = require('hsp/$set');
 
-{template test1(model)}
+<template test1(model)>
     <div class="test"></div>
     <div class="{{'active': model.isActive}}"></div>
     <div class="base {{'active': model.isActive}}"></div>
     <div class="{model.list}"></div>
     <div class="base {model.more}"></div>
-{/template}
+</template>
 
 describe("Class attribute", function () {
 

--- a/test/rt/attributes/modelvalue.spec.hsp
+++ b/test/rt/attributes/modelvalue.spec.hsp
@@ -18,7 +18,7 @@ var hsp=require("hsp/rt"),
     json=require("hsp/json"),
     ht=require("hsp/utils/hashtester");
 
-{template inputSample(data)}
+<template inputSample(data)>
     <div class="info section">All the following inputs are synchronized:</div>
     <div class="section">
         Comment #1: <input id="1" type="text" value="{data.comment}"/><br/>
@@ -41,18 +41,18 @@ var hsp=require("hsp/rt"),
         <label for="rb3">Select C</label> -
         Selection in model: <span class="textValue">{data.selection}</span>
     </div>
-{/template}
+</template>
 
-{template enterEmptiesFieldSample(object)}
+<template enterEmptiesFieldSample(object)>
     <div class="info section">Please type a command and press enter.</div>
     <pre>{object.commandsHistory}</pre>
     <input type="text" value="{object.value}" onkeydown="{object.keydown(event)}" placeholder="Your command"><br>
     <input type="text" value="{object.value}" onkeydown="{object.keydown(event)}" placeholder="Your command"><br>
-{/template}
+</template>
 
-{template html5NumberInput(model)}
+<template html5NumberInput(model)>
     <div><input type="number" model="{model.value}"/></div>
-{/template}
+</template>
 
 describe("Input Elements", function () {
     it("input model sync", function () {
@@ -235,9 +235,9 @@ describe("Input Elements", function () {
     });
 });
 
-{template test1(data)}
+<template test1(data)>
     <textarea rows="4" cols="40"  model="{data.text}"/>
-{/template}
+</template>
 
 // normalize carriage returns to avoid OS discrepancies
 function normalizeCR(s) {

--- a/test/rt/booleanAttributes.spec.hsp
+++ b/test/rt/booleanAttributes.spec.hsp
@@ -1,10 +1,10 @@
 var json=require("hsp/json");
 hsp=require("hsp/rt");
 
-{template tpl(model)}
+<template tpl(model)>
 <input type = "text" required = "{model.flag}">
 <input type = "radio" checked = "{model.flag2}">
-{/template}
+</template>
 
 describe('boolean attributes', function () {
 

--- a/test/rt/cptattelements1.spec.hsp
+++ b/test/rt/cptattelements1.spec.hsp
@@ -27,7 +27,7 @@ PanelController = klass({
 });
 
 // sample panel template
-{template panel using c:PanelController}
+<template panel using c:PanelController>
   <div class="panel">
     {if c.head}
       <div class="head">
@@ -41,64 +41,64 @@ PanelController = klass({
       <div class="footer">TODO</div>
     {/if}
   </div>
-{/template}
+</template>
 
-{template test1(m)}
+<template test1(m)>
   Sample panel:
   <#panel>
     <@body>
       {m.text}!
     </@body>
   </#panel>
-{/template}
+</template>
 
-{template test2()}
+<template test2()>
   Sample panel:
   <#panel body="Hello World!"/>
-{/template}
+</template>
 
-{template test3(m)}
+<template test3(m)>
   Sample panel:
   <#panel body="{m.text}!"/>
-{/template}
+</template>
 
-{template test4(m)}
+<template test4(m)>
   Sample panel:
   <#panel>{m.text}!</#panel>
-{/template}
+</template>
 
-{template test5(m)}
+<template test5(m)>
   Sample panel:
   <#m.panel><@body>{m.text}!</@body></#m.panel>
-{/template}
+</template>
 
-{template test6(m)}
+<template test6(m)>
   Sample panel:
   <#m.panel>{m.text}!!!</#m.panel>
-{/template}
+</template>
 
-{template test7(m)}
+<template test7(m)>
   Sample panel:
   <#m.panel>
   {if true}{m.text}!{/if} <hr/> {m.text} <a>Update model</a>
   </#m.panel>
-{/template}
+</template>
 
-{template test8(m)}
+<template test8(m)>
   Sample panel:
   <#m.panel>
     {if true}{m.text}!{/if}
     <@body>foo <a>Update model</a> </@body>
   </#m.panel>
-{/template}
+</template>
 
-{template panel2 using c:PanelController}
+<template panel2 using c:PanelController>
   <div class="panel">
     <div class="body">
       Body content: <#c.body/>
     </div>
   </div>
-{/template}
+</template>
 
 var TestCtl=klass({
       attributes:{
@@ -106,15 +106,15 @@ var TestCtl=klass({
     }
 })
 
-{template item using c:TestCtl}
+<template item using c:TestCtl>
     Value: {c.value}
-{/template}
+</template>
 
-{template test7(m)}
+<template test7(m)>
   <div class="content">
     <#item value="{m.prop.value}"/>
   </div>
-{/template}
+</template>
 
 var HEAD=".panel .head";
 var BODY=".panel .body";

--- a/test/rt/cptattelements2.spec.hsp
+++ b/test/rt/cptattelements2.spec.hsp
@@ -37,20 +37,20 @@ var ExpandCollapseController = klass({
     }
 });
 
-{template expandCollapse using c:ExpandCollapseController}
+<template expandCollapse using c:ExpandCollapseController>
     {if c.visible}
         <a onclick="{c.hide()}">Hide</a><br/>
         <#c.body />
     {else}
         <a onclick="{c.show()}">Show</a><br/>
     {/if}
-{/template}
+</template>
 
-{template test(data)}
+<template test(data)>
     <#expandCollapse>
         <span class="content">My content</span>
     </#expandCollapse>
-{/template}
+</template>
 
 
 var LINK="a";

--- a/test/rt/cptattelements3.spec.hsp
+++ b/test/rt/cptattelements3.spec.hsp
@@ -25,7 +25,7 @@ var ListController = klass({
     }
 });
 
-{template list using lc:ListController}
+<template list using lc:ListController>
     {if !lc.content} 
         <span class="nodata">Empty list</span>
     {else}
@@ -37,23 +37,23 @@ var ListController = klass({
             {/foreach}
         </ul>
     {/if}
-{/template}
+</template>
 
-{template test1()}
+<template test1()>
     <#list>
         
     </#list>
-{/template}
+</template>
 
-{template test2(d)}
+<template test2(d)>
     <#list>
         <@option>First {d.itemName}</@option>
         <@option>Second item</@option>
         <@option>Third {d.itemName}</@option>
     </#list>
-{/template}
+</template>
 
-{template test3(d)}
+<template test3(d)>
     <#list>
         {if d.displayFirstAndLastItems}
             <@option>First {d.itemName}</@option>
@@ -67,16 +67,16 @@ var ListController = klass({
             {/if}
         {/if}
     </#list>
-{/template}
+</template>
 
-{template test4(d)}
+<template test4(d)>
     <#list>
         <@option>1. First {d.itemName}</@option>
         {foreach idx,itm in d.items}
             <@option>{idx+2}. {itm}</@option>
         {/foreach}
     </#list>
-{/template}
+</template>
 
 
 

--- a/test/rt/cptattelements4.spec.hsp
+++ b/test/rt/cptattelements4.spec.hsp
@@ -46,7 +46,7 @@ var ListCtrl = klass({
     }
 });
 
-{template list using lc:ListCtrl}
+<template list using lc:ListCtrl>
     {if !lc.content} 
         <span class="nodata">Empty list</span>
     {else}
@@ -58,33 +58,33 @@ var ListCtrl = klass({
             {/foreach}
         </ul>
     {/if}
-{/template}
+</template>
 
-{template test1()}
+<template test1()>
     <#list>
         <@option value="A" label="First"/>
         <@option value="B">Second</@option>
     </#list>
-{/template}
+</template>
 
-{template test2(d)}
+<template test2(d)>
     <#list>
         <@option value="A{d.suffix}" label="First {d.txt}"/>
         <@option value="B{d.suffix}">Second {d.txt}</@option>
     </#list>
-{/template}
+</template>
 
-{template test3(d)}
+<template test3(d)>
     <#list>
         {foreach idx,itm in d.items}
             <@option value="{idx}">{idx+1}. {itm}</@option>
         {/foreach}
     </#list>
-{/template}
+</template>
 
-{template tabA(tab)}
+<template tabA(tab)>
   {tab.title}
-{/template}
+</template>
 
 var TabCtrl = klass({
   $init: function () {
@@ -100,7 +100,7 @@ var TabCtrl = klass({
   }
 });
 
-{template tabs using c:TabCtrl}
+<template tabs using c:TabCtrl>
   <ul class="nav nav-tabs">
   {foreach index,tab in c.tabs}
     <li><a href="#">
@@ -113,7 +113,7 @@ var TabCtrl = klass({
     </a></li>
   {/foreach}
   </ul>
-{/template}
+</template>
 
 var EMPTY_MSG=".nodata";
 var OPTIONS="ul .opt";

--- a/test/rt/cptattelements5.spec.hsp
+++ b/test/rt/cptattelements5.spec.hsp
@@ -57,7 +57,7 @@ var TabBarCtrl = klass({
     }
 });
 
-{template tabbar using ctrl:TabBarCtrl}
+<template tabbar using ctrl:TabBarCtrl>
   <div class="x-tabbar">
     <nav class="x-tabs">
         {foreach idx, tab in ctrl.content}
@@ -77,17 +77,17 @@ var TabBarCtrl = klass({
         <#ctrl.selectedTab.body />
     </div>
   </div>
-{/template}
+</template>
 
-{template test1(m)}
+<template test1(m)>
   <#tabbar selection="{m.selection}">
     <@tab label="Tab A">AAA Content AAA</@tab>
     <@tab label="Tab B">BBB Content BBB</@tab>
     <@tab label="Tab C">CCC Content CCC</@tab>
   </#tabbar>
-{/template}
+</template>
 
-{template test2(m)}
+<template test2(m)>
   <#tabbar selection="{m.selection1}">
     <@tab label="Tab A">
         <#tabbar selection="{m.selection2}">
@@ -98,7 +98,7 @@ var TabBarCtrl = klass({
     <@tab label="Tab B">BBB Content BBB</@tab>
     <@tab label="Tab C">CCC Content CCC</@tab>
   </#tabbar>
-{/template}
+</template>
 
 var TABS=".x-tab";
 var BODY=".x-tab-content";

--- a/test/rt/cptbinding.spec.hsp
+++ b/test/rt/cptbinding.spec.hsp
@@ -30,16 +30,16 @@ var Cpt1 = klass({
   }
 });
 
-{template cpt1 using c:Cpt1}
+<template cpt1 using c:Cpt1>
   <input type="text" value="{c.value}"/>
-{/template}
+</template>
 
-{template test(d)}
+<template test(d)>
   <#cpt1 value="{d.value}" max="{d.max}" defaultvalue="{d.defaultvalue}"/>
   <input type="text" value="{d.value}"/>
   <input type="text" value="{d.max}"/>
   <input type="text" value="{d.defaultvalue}"/>
-{/template}
+</template>
 
 var checks=[], lastInitValue=null, dataValue=null;
 var Cpt2 = klass({ 
@@ -60,17 +60,17 @@ var Cpt2 = klass({
   }
 });
 
-{template cpt2 using c:Cpt2}
+<template cpt2 using c:Cpt2>
   <input type="text" value="{c.value}"/>
-{/template}
+</template>
 
-{template test2(d)}
+<template test2(d)>
   <#cpt2 value="{d.value}" initvalue="10"/>
-{/template}
+</template>
 
-{template test3(d)}
+<template test3(d)>
   <#cpt2 value="{d.value}" data="{d.data}"/>
-{/template}
+</template>
 
 var setFieldValue=function(field,value) {
   // helper function

--- a/test/rt/cptinit.spec.hsp
+++ b/test/rt/cptinit.spec.hsp
@@ -27,39 +27,39 @@ var TestCtrl=klass({
   }
 });
 
-{template cpt using c:TestCtrl}
+<template cpt using c:TestCtrl>
     <div class="cpt">{c.value}</div>
-{/template}
+</template>
 
-{template test1(d)}
+<template test1(d)>
       {if d.show}
           <div class="foo">
               <#cpt value="{d.getValue()}" oninit="{d.update()}"/>
           </div>
       {/if}
-{/template}
+</template>
 
-{template test2(items)}
+<template test2(items)>
       {foreach itm in items}
           <div class="foo">
               <#cpt value="{itm.getValue()}" oninit="{itm.update()}"/>
           </div>
       {/foreach}
-{/template}
+</template>
 
-{template tpA}
+<template tpA>
   AA
-{/template}
+</template>
 
-{template tpB(data)}
+<template tpB(data)>
   <div class="foo">
       <#cpt value="{data.getValue()}" oninit="{data.update()}"/>
   </div>
-{/template}
+</template>
 
-{template test3(ctxt,d)}
+<template test3(ctxt,d)>
     <#ctxt.tpl data="{d}"/>
-{/template}
+</template>
 
 var Model=klass({
   $constructor:function(v) {

--- a/test/rt/cptintegration.spec.hsp
+++ b/test/rt/cptintegration.spec.hsp
@@ -41,25 +41,25 @@ var TestCtrl1=klass({
   }
 });
 
-{template test1 using c:TestCtrl1}
+<template test1 using c:TestCtrl1>
   Hello
   <div class="foo">
     Blah
   </div>
   <div class="bar" title="hello"></div>
-{/template}
+</template>
 
-{template test2}
+<template test2>
   <div class="bar" title="foo1"></div>
   <#test1/>
   <div class="bar" title="foo2"></div>
-{/template}
+</template>
 
-{template test3(d)}
+<template test3(d)>
   {if d.ok}
     <#test1 value="{d.input}"/>
   {/if}
-{/template}
+</template>
 
 
 describe("External component integration", function () {

--- a/test/rt/cptrefresh.spec.hsp
+++ b/test/rt/cptrefresh.spec.hsp
@@ -22,16 +22,16 @@ var Cpt1 = klass({
   }
 });
 
-{template cpt1 using c:Cpt1}
+<template cpt1 using c:Cpt1>
 {if !c.closed}
   <button onclick="{c.close()}">Close</button>
 {/if}
-{/template}
+</template>
 
-{template test1(d)}
+<template test1(d)>
   <#cpt1 />
   <#d.cpt />
-{/template}
+</template>
 
 
 describe("Component refresh", function () {

--- a/test/rt/cptwrapper.spec.hsp
+++ b/test/rt/cptwrapper.spec.hsp
@@ -115,24 +115,23 @@ lib.NbrField = klass({
   }
 })
 
-
-{template nbrfield using c:lib.NbrField}
+<template nbrfield using c:lib.NbrField>
   <input type="text" model="{c.internalValue}" class="nbrfield {{'error': c.invalidValue, 'mandatory': c.mandatory}}"/>
   <input type="button" value="..." onclick="{c.resetField()}"/>
-{/template}
+</template>
 
 lib.nbrfield=nbrfield;
 
-{template test(d)}
+<template test(d)>
   <input type="text" value="{d.value}"/>
   <#lib.nbrfield value="{d.value}" min="-10" max="10" onbeforereset="{notifyReset(123,event)}" 
   onafterreset="{notifyReset2(event.type,event)}"/>
-{/template}
+</template>
 
-{template test2(d)}
+<template test2(d)>
   <input type="text" value="{d.value}"/>
   <#lib.nbrfield value="{d.value}" min="-10" max="10"/>
-{/template}
+</template>
 
 var resetCount=0, lastResetArg=0, lastEvtType="";
 function notifyReset(arg,evt) {
@@ -162,9 +161,9 @@ var HelloCtrl = klass({
     }
 });
 
-{template test3 using ctrl:HelloCtrl}
+<template test3 using ctrl:HelloCtrl>
    <input type="checkbox" model="{ctrl.inputChecked}">
-{/template}
+</template>
 
 describe("Component Nodes", function () {
   var ELEMENT_NODE=1;

--- a/test/rt/customAttributes.spec.hsp
+++ b/test/rt/customAttributes.spec.hsp
@@ -1,31 +1,31 @@
 var hsp = require("hsp/rt");
 var klass = klass=require("hsp/klass");
 
-{template test1()}
+<template test1()>
     <div style="height: 20px" verybigdiv>
         <span>Test</span>
     </div>
-{/template}
+</template>
 
-{template test2()}
+<template test2()>
     <div style="height: 20px" customheightdiv="50">
         <span>Test</span>
     </div>
-{/template}
+</template>
 
-{template test3(ctl)}
+<template test3(ctl)>
     <div style="height: 20px" customheightdiv="{ctl.myHeight}" class="{{'active': ctl.isActive}}">
         <span>Test</span>
     </div>
-{/template}
+</template>
 
-{template test4()}
+<template test4()>
     <div style="height: 20px" customheightdiv="50" verybigdiv>
         <span>Test</span>
     </div>
-{/template}
+</template>
 
-{template test5()}
+<template test5()>
     <div>
         <div>
             <span customButton>
@@ -33,22 +33,22 @@ var klass = klass=require("hsp/klass");
             </span>
         </div>
     </div>
-{/template}
+</template>
 
-{template test6()}
+<template test6()>
     <div style="height: 20px" customone="50" customtwo>
         <span>Test</span>
     </div>
-{/template}
+</template>
 
-{template test7()}
+<template test7()>
     <div id="found" verybigdiv>
         <span>
             <button customButton/>
             <input customButton/>
         </span>
     </div>
-{/template}
+</template>
 
 describe("Custom attributes", function () {
 

--- a/test/rt/dynexpressions.spec.hsp
+++ b/test/rt/dynexpressions.spec.hsp
@@ -19,35 +19,35 @@ function foo(arg1,arg2) {
     return arg1+arg2;
 }
 
-{template test1(d)}
+<template test1(d)>
     <div class="content">Value: {d.person[d.pp]}</div>
-{/template}
+</template>
 
-{template test2(d)}
+<template test2(d)>
     <div class="content">Value: {d.person[d.pp1+d.pp2]}</div>
-{/template}
+</template>
 
-{template test3(d)}
+<template test3(d)>
     <div class="content">Value: {d.person[foo(d.pp1,d.pp2)].value}</div>
-{/template}
+</template>
 
-{template test4(d)}
+<template test4(d)>
     <div class="content">Value: {d.person[d[d.prop]].value}</div>
-{/template}
+</template>
 
-{template test5(d)}
+<template test5(d)>
     <div class="content" title="{d.person[d.pp1][d.pp2]}">...</div>
-{/template}
+</template>
 
-{template test6(d)}
+<template test6(d)>
     <div class="content">
         {if d.person[d.pp+"Name"].value === d.condition}TRUE{else}FALSE{/if}
     </div>
-{/template}
+</template>
 
-{template test7(d)}
+<template test7(d)>
     <input type="text" model="{d.person[d.pp]}">
-{/template}
+</template>
 
 describe("Dynamic path expressions", function () {
     var C=".content";

--- a/test/rt/elt.spec.hsp
+++ b/test/rt/elt.spec.hsp
@@ -21,36 +21,36 @@ var hsp=require("hsp/rt"),
     klass=require("hsp/klass");
 
 
-{template test1(person)}
+<template test1(person)>
     <div title="test1">
         Hello {person.name}!
     </div>
-{/template}
+</template>
 
-{template test2(person)}
+<template test2(person)>
     <div title="test2" class="t2 {person.gender}" tabIndex="{person.idx}">
         {person.firstName} / {person.lastName} 
         [ <span class="{person.ffLevel}">
             Frequent flyer #: {person.ffNbr}
         </span> ]
     </div>
-{/template}
+</template>
 
-{template test3(person)}
+<template test3(person)>
     <input type="text" value="{person.name}"/>
-{/template}
+</template>
 
 
 var globalObject={value:"foo"};
-{template test4()}
+<template test4()>
     <input type="text" value="{globalObject.value}"/>
-{/template}
+</template>
 
-{template test5(name)}
+<template test5(name)>
     <div style="color:red;">
         Hello {name}!
     </div>
-{/template}
+</template>
 
 var TestCtl6=klass({
     attributes: {
@@ -66,11 +66,11 @@ var TestCtl6=klass({
     }
 });
 
-{template test6 using c:TestCtl6}
+<template test6 using c:TestCtl6>
     // test onchange cross browser consitency
     <input type="checkbox" model="{c.selected}" onchange="{c.processChange()}">
     <span class="label">{c.label}</span>
-{/template}
+</template>
 
 describe("Element Nodes", function () {
     var ELEMENT_NODE=1;

--- a/test/rt/evthandler.spec.hsp
+++ b/test/rt/evthandler.spec.hsp
@@ -17,29 +17,29 @@
 var ht=require("hsp/utils/hashtester"),
     fireEvent=require("hsp/utils/eventgenerator").fireEvent;
 
-{template test1(person,ctl)}
+<template test1(person,ctl)>
     <div title="test1" onclick="{ctl.handleClick()}">
         Hello {person.name}!
     </div>
-{/template}
+</template>
 
-{template test2(label,names,ctl)}
+<template test2(label,names,ctl)>
     {foreach key,name in names}
         <span onclick="{ctl.handleClick(name,key,'literal arg',event)}">
             {:label} {key}: {:name}
         </span>
     {/foreach}
-{/template}
+</template>
 
-{template test3(person)}
+<template test3(person)>
     <div title="test3" onclick="{doClick('blah',event)}">
         Hello {person.name}!
     </div>
-{/template}
+</template>
 
-{template test4()}
+<template test4()>
     <img onclick="this.cbatt=123;return false;"/>
-{/template}
+</template>
 
 
 var doClickCount = 0, doClickEvtType = "", doClickStrArg = "";

--- a/test/rt/exprbinding.spec.hsp
+++ b/test/rt/exprbinding.spec.hsp
@@ -24,12 +24,12 @@ function changeValue (data,val) {
     $set(data.object,"value",val);
 }
 
-{template test1(data) }
+<template test1(data) >
     <input class="in1" type="text" value="{data.object.value}" />
     <input class="in2" type="text" value="{data.object.value}" />
-{/template}
+</template>
 
-{template header(document)}
+<template header(document)>
   <div class="title"> 
       {if document && document.title}
         {document.title}
@@ -37,26 +37,26 @@ function changeValue (data,val) {
         Untitled document
       {/if}
   </div>
-{/template}
+</template>
 
-{template test2(data)}
+<template test2(data)>
    <#header document="{data.document}" />
-{/template}
+</template>
 
 
-{template title(document)}
+<template title(document)>
   {if document && document.title}
     {document.title}
   {else}
     No title
   {/if}
-{/template}
+</template>
 
-{template test3(data)}
+<template test3(data)>
   <div class="content">
     <#title document="{data.document}" />
   </div>
-{/template}
+</template>
 
 describe("Expression Bindings", function () {
     var INPUT1=".in1", INPUT2=".in2";

--- a/test/rt/filescope.spec.hsp
+++ b/test/rt/filescope.spec.hsp
@@ -22,16 +22,16 @@ function globalHelper() {
     return true;
 }
 
-{template test1}
+<template test1>
     {if (globalHelper())}
         <div class="test">I am here because of a global helper</div>
     {/if}
-{/template}
+</template>
 
-{template test2}
+<template test2>
   <#test1 />
   <#test1 />
-{/template}
+</template>
 
 describe("Templates using expressions with global references", function () {
 

--- a/test/rt/fnexpressions.spec.hsp
+++ b/test/rt/fnexpressions.spec.hsp
@@ -23,41 +23,41 @@ function endText(a) {
     return "*"+a+"*";
 }
 
-{template test1(d)}
+<template test1(d)>
     <div class="content" title="{d.fn(d.msg1,d.msg2)}">foo</div>
-{/template}
+</template>
 
-{template test2(d)}
+<template test2(d)>
     <div class="content" title="{concat(d.msg1,d.msg2)}!">foo</div>
-{/template}
+</template>
 
-{template test3(d)}
+<template test3(d)>
     <div class="content" title="{d.sub.fn(d.msg1,d.msg2)}">foo</div>
-{/template}
+</template>
 
-{template test4(d)}
+<template test4(d)>
     <div class="content">
         {d.fn(d.msg1,d.msg2)}!
         {if d.showEndText}
             {endText(123)}
         {/if}
     </div>
-{/template}
+</template>
 
-{template test5(d)}
+<template test5(d)>
     <div class="content">A {concat(d.msg1,d.msg2)} B</div>
-{/template}
+</template>
 
-{template test6(d)}
+<template test6(d)>
     <div class="content">{d.sub.fn(d.msg1,d.msg2)}</div>
-{/template}
+</template>
 
 function InvalidModifier() {}
 
-{template test7(d)}
+<template test7(d)>
     {let modifier=new InvalidModifier()}
     <div class="content">{d.msg|modifier}</div>
-{/template}
+</template>
 
 describe("Function expressions", function () {
     var C=".content";

--- a/test/rt/foreach.spec.hsp
+++ b/test/rt/foreach.spec.hsp
@@ -20,7 +20,7 @@ var hsp=require("hsp/rt"),
     ht=require("hsp/utils/hashtester"),
     klass=require("hsp/klass");
 
-{template test1(label,names)}
+<template test1(label,names)>
     {foreach (name in names)}
         <span class="name">
             {label} {name_key}: {name} ({:name.length} chars)
@@ -29,9 +29,9 @@ var hsp=require("hsp/rt"),
             Number of items: {:names.length}
         {/if}
     {/foreach}
-{/template}
+</template>
 
-{template test2(ds)}
+<template test2(ds)>
     {foreach idx,person in ds.persons}
         Person #{idx}: {person.firstName} {person.lastName}
         {if (person_isfirst)}
@@ -41,15 +41,15 @@ var hsp=require("hsp/rt"),
             (last)
         {/if}
     {/foreach}
-{/template}
+</template>
 
-{template test3(things) }
+<template test3(things) >
     {foreach (oneThing in things)}
         {oneThing}
     {/foreach}
-{/template}
+</template>
 
-{template test4(things)}
+<template test4(things)>
     {foreach oneThing in things}
         {if oneThing_isfirst}
             First
@@ -63,15 +63,15 @@ var hsp=require("hsp/rt"),
         {oneThing}
         <br/>
     {/foreach}
-{/template}
+</template>
 
-{template test5(persons) }
+<template test5(persons) >
     {foreach person in persons}
         {person.name}
     {/foreach}
-{/template}
+</template>
 
-{template test6(itemsList)}
+<template test6(itemsList)>
     {foreach item in itemsList}
         {if item.edit}
             <input type="text" value="{item.value}">
@@ -79,19 +79,19 @@ var hsp=require("hsp/rt"),
             <span>{item.value}</span>
         {/if}
     {/foreach}
-{/template}
+</template>
 
 var items=[
     {value:"Iteam A"},
     {value:"Item B"}
 ];
-{template test7}
+<template test7>
     {foreach item in items}
         <div class="itm">
             {item.value}
         </div>
     {/foreach}
-{/template}
+</template>
 
 var Sorter=klass({
     $constructor:function(property) {
@@ -124,7 +124,7 @@ var Sorter=klass({
     }
 });
 
-{template test8(d)}
+<template test8(d)>
     <div class="section2">
         {let fnSorter=new Sorter("firstName")}
         <ol>
@@ -138,9 +138,9 @@ var Sorter=klass({
             Toggle sort order (current: {fnSorter.ascending? "ascending" : "descending"})
         </a>
     </div>
-{/template}
+</template>
 
-{template test9(d,ppName)}
+<template test9(d,ppName)>
     <div class="section2">
         {let fnSorter=new Sorter("firstName")}
         <ol>
@@ -154,9 +154,9 @@ var Sorter=klass({
             Toggle sort order (current: {fnSorter.ascending? "ascending" : "descending"})
         </a>
     </div>
-{/template}
+</template>
 
-{template test10(d)}
+<template test10(d)>
     <div class="section2">
         {let nameSort=new Sorter("firstName")}
         <ol>
@@ -170,7 +170,7 @@ var Sorter=klass({
             Toggle sort order (current: {nameSort.ascending? "ascending" : "descending"})
         </a>
     </div>
-{/template}
+</template>
 
 describe("ForEach Node", function () {
     function test1Count (arrayLength) {

--- a/test/rt/foreach_globals.spec.hsp
+++ b/test/rt/foreach_globals.spec.hsp
@@ -3,7 +3,7 @@ var hsp=require("hsp/rt"),
 
 hsp.global.orderBy = require("hsp/rt/colutils").orderBy;
 
-{template test(d)}
+<template test(d)>
 <div class="section2">
     <ol>
         {foreach p in d.persons|orderBy:"name"}
@@ -11,7 +11,7 @@ hsp.global.orderBy = require("hsp/rt/colutils").orderBy;
         {/foreach}
     </ol>
 </div>
-{/template}
+</template>
 
 describe('repeater with global pipe functions', function() {
     it("validates collection sorting through pipe expression being global", function() {

--- a/test/rt/global.spec.hsp
+++ b/test/rt/global.spec.hsp
@@ -17,42 +17,42 @@
 var hsp=require("hsp/rt"),
     ht=require("hsp/utils/hashtester");
 
-{template test1()}
+<template test1()>
     <div class="content">Hello {msg}</div>
-{/template}
+</template>
 
-{template test2()}
+<template test2()>
     <div class="content">{g.msg}!</div>
-{/template}
+</template>
 
-{template w1(message)}
+<template w1(message)>
     <span class="wmsg">{message}</span>
-{/template}
+</template>
 
-{template test3(msg)}
+<template test3(msg)>
     <div class="content">
         <#mywidget message="{msg}"/>
     </div>
-{/template}
+</template>
 
-{template test4(msg)}
+<template test4(msg)>
     <div class="content">
         <#lib.widget message="{msg}"/>
     </div>
-{/template}
+</template>
 
-{template test5(values)}
+<template test5(values)>
     <div class="content">
         Values: {mytransform(values)}
     </div>
-{/template}
+</template>
 
-{template test6(values)}
+<template test6(values)>
     {let t=new TestTransform("A")}
     <div class="content">
         Values: {t.process(values)}
     </div>
-{/template}
+</template>
 
 
 describe("Hashspace global object", function () {

--- a/test/rt/if.spec.hsp
+++ b/test/rt/if.spec.hsp
@@ -17,13 +17,13 @@
 var hsp=require("hsp/rt"),
     json=require("hsp/json");
 
-{template test1(person)}
+<template test1(person)>
     {if (person.firstName)}
         Hello {person.firstName}
     {/if}
-{/template}
+</template>
 
-{template test2(person)}
+<template test2(person)>
     {if person.firstName}
         <h2>Hello {person.firstName}</h2>
         {if (person.favouriteDish)}
@@ -34,34 +34,34 @@ var hsp=require("hsp/rt"),
             Hello {person.lastName}
         </div>
     {/if}
-{/template}
+</template>
 
-{template test3(person)}
+<template test3(person)>
     Hello 
     {if person.firstName}
         {person.firstName}!
     {/if}
-{/template}
+</template>
 
-{template test4(person)}
+<template test4(person)>
     Hello 
     // test literal as if parameter - even if it doesn't really make sense, should still be supported - e.g. for debugging purposes
     {if (true)}
         {person.firstName}!
     {/if}
-{/template}
+</template>
 
-{template test5(data)}
+<template test5(data)>
   {if (data.value === "test" || data.value===false || data.value===null || data.value===123)} 
     Hello
   {/if}
-{/template}
+</template>
 
-{template test6}
+<template test6>
   {if (!false)} 
     Hello
   {/if}
-{/template}
+</template>
 
 
 describe("If Node", function () {

--- a/test/rt/let.spec.hsp
+++ b/test/rt/let.spec.hsp
@@ -20,7 +20,7 @@ var hsp=require("hsp/rt"),
     log=require("hsp/rt/log"),
     ht=require("hsp/utils/hashtester");
 
-{template test1(d)}
+<template test1(d)>
     {let x=d.value, y=x+3}
     <div class="foo">
         Blah
@@ -29,9 +29,9 @@ var hsp=require("hsp/rt"),
     <span class="bar">
         {y+'AL'}
     </span>
-{/template}
+</template>
 
-{template test2(d)}
+<template test2(d)>
     <div class="foo">
         {let x=d.value+' World'}
         {x}
@@ -39,9 +39,9 @@ var hsp=require("hsp/rt"),
     <span class="bar">
         {x}
     </span>
-{/template}
+</template>
 
-{template test3(d)}
+<template test3(d)>
     <div class="foo">
         {if d.condition}
             {let x=d.value1+' World'}
@@ -51,9 +51,9 @@ var hsp=require("hsp/rt"),
             x: {x} - y: {y}
         {/if}
     </div>
-{/template}
+</template>
 
-{template test4(d)}
+<template test4(d)>
     <div class="foo">
         <ul>
             {foreach city in d.cities}
@@ -63,7 +63,7 @@ var hsp=require("hsp/rt"),
         </ul>
     </div>
     <div class="bar">{nm}</div>
-{/template}
+</template>
 
 describe("Let statement", function () {
   

--- a/test/rt/log.spec.hsp
+++ b/test/rt/log.spec.hsp
@@ -20,26 +20,26 @@ var hsp=require("hsp/rt"),
     log=require("hsp/rt/log"),
     ht=require("hsp/utils/hashtester");
 
-{template test1(d)}
+<template test1(d)>
     Some text
     <div class="foo">
         Blah
         {log d.value}
     </div>
-{/template}
+</template>
 
-{template test2(d)}
+<template test2(d)>
     <div class="foo">
         ...
         {log d.value1, d.value2}
     </div>
-{/template}
+</template>
 
-{template test3(cities)}
+<template test3(cities)>
     {foreach idx,city in cities}
         {log idx+":", scope}
     {/foreach}
-{/template}
+</template>
 
 describe("Log statement", function () {
   

--- a/test/rt/subtemplates1.spec.hsp
+++ b/test/rt/subtemplates1.spec.hsp
@@ -18,68 +18,68 @@ var hsp=require("hsp/rt"),
     fireEvent=require("hsp/utils/eventgenerator").fireEvent,
     json=require("hsp/json");
 
-{template content(label, value)}
+<template content(label, value)>
     {:label}: {value}
-{/template}
+</template>
 
-{template test1(person)}
+<template test1(person)>
     Before
     <#content label="First Name" value="{person.firstName}"/>
     After
-{/template}
+</template>
 
-{template nameDetails(person)}
+<template nameDetails(person)>
     <#content value="{person.lastName}" label="Last Name"/>
     {if (person.firstName)}
         , 
         <#content label="First Name" value="{person.firstName}"/>
     {/if}
-{/template}
+</template>
 
-{template test2(p)}
+<template test2(p)>
     <#nameDetails person="{p}"/>
-{/template}
+</template>
 
-{template test3(person, label)}
+<template test3(person, label)>
     // inserted template also has a label argument
     {label}
     <#content label="{person.firstName}" value="{:person.lastName}"/>
-{/template}
+</template>
 
 function concat(a,b) {
     return a+": "+b;
 }
 
-{template test4(person)}
+<template test4(person)>
     {concat(person.firstName, person.lastName)}
-{/template}
+</template>
 
-{template field(label,value)}
+<template field(label,value)>
     {label}
     <input type="text" value="{value}"/>
-{/template}
+</template>
 
-{template test5(d)}
+<template test5(d)>
     <#field label="Enter some text" value="{d.text}"/>
-{/template}
+</template>
 
-{template field2(attributes)}
+<template field2(attributes)>
     Enter some text: 
     <input type="text" value="{attributes.value}"/>
-{/template}
+</template>
 
-{template test6(d)}
+<template test6(d)>
     <#field2 attributes="{d.attributes}"/>
-{/template}
+</template>
 
-{template field3(attributes)}
+<template field3(attributes)>
     Enter some text: 
     <input type="text" value="{attributes.myvalue.value}"/>
-{/template}
+</template>
 
-{template test7(d)}
+<template test7(d)>
     <#field3 attributes="{{myvalue: d}}"/>
-{/template}
+</template>
 
 describe("Sub-template insertion", function () {
     it("tests a simple insertion", function () {

--- a/test/rt/subtemplates2.spec.hsp
+++ b/test/rt/subtemplates2.spec.hsp
@@ -17,49 +17,49 @@
 var ht=require("hsp/utils/hashtester"),
     klass=require("hsp/klass");
 
-{template test1(c)}
+<template test1(c)>
     <div class="content">
         Before -
         <#c.tpl/> 
         - After
     </div>
-{/template}
+</template>
 
-{template contentA}
+<template contentA>
     This is contentA 
-{/template}
+</template>
 
-{template contentB}
+<template contentB>
     This is contentB 
-{/template}
+</template>
 
-{template contentC}
+<template contentC>
     This is contentC 
-{/template}
+</template>
 
-{template test2(c)}
+<template test2(c)>
     <div class="content">
         Before -
         <#c.a.b.tpl/> 
         - After
     </div>
-{/template}
+</template>
 
-{template test3(c)}
+<template test3(c)>
     <div class="content">
         Before -
         <#c.tpl msg="{c.txt}"/> 
         - After
     </div>
-{/template}
+</template>
 
-{template contentA2(msg)}
+<template contentA2(msg)>
     contentA2: {msg} 
-{/template}
+</template>
 
-{template contentB2(msg)}
+<template contentB2(msg)>
     contentB2: {msg} 
-{/template}
+</template>
 
 var C2Controller=klass({
     attributes:{
@@ -68,23 +68,23 @@ var C2Controller=klass({
     }
 });
 
-{template contentC2 using c:C2Controller}
+<template contentC2 using c:C2Controller>
     contentC2: {c.msg} {c.foo} 
-{/template}
+</template>
 
 var ctxt={
     tpl:contentA2,
     msg:"hello"
 }
-{template test4(ctxt)}
+<template test4(ctxt)>
     <div class="content">
         Before -
         <#ctxt.tpl msg="{ctxt.msg}"/> 
         - After
     </div>
-{/template}
+</template>
 
-{template test5(c)}
+<template test5(c)>
     {let x=c.a}
     <div class="content">
         {let y=x.b}
@@ -92,7 +92,7 @@ var ctxt={
         <#y.tpl/> 
         - After
     </div>
-{/template}
+</template>
 
 describe("Dynamic template insertion", function () {
     it("validates dynamic insertion with no template argument", function() {

--- a/test/rt/subtemplates3.spec.hsp
+++ b/test/rt/subtemplates3.spec.hsp
@@ -25,11 +25,11 @@ var removeItem = function (items, index) {
    items.splice(index, 1);
 };
 
-{template displayItem(itms, idx)}
+<template displayItem(itms, idx)>
     <li onclick="{removeItem(itms, 0)}">Remove #{idx}</li>
-{/template}
+</template>
 
-{template list(items)}
+<template list(items)>
     <ul>
         {foreach index,curItem in items}
             {if true}
@@ -39,31 +39,31 @@ var removeItem = function (items, index) {
         {/foreach}
     </ul>
     <a onclick="{addItem(items)}">Add item</a>
-{/template}
+</template>
 
-{template item(value)}
+<template item(value)>
     Value: {value}
-{/template}
+</template>
 
-{template test1(m)}
+<template test1(m)>
     <div class="content">
         <#item value="{m.prop.value}"/>
     </div>
-{/template}
+</template>
 
-{template innerTemplate(data)}
+<template innerTemplate(data)>
     {if data.checked}[x]{else}[ ]{/if} Checked
-{/template}
+</template>
 
-{template intermediateTemplate(data)}
+<template intermediateTemplate(data)>
   <#innerTemplate data="{data}"/>
-{/template} 
+</template> 
 
-{template test2(data)}
+<template test2(data)>
   <div class="content">
     <#data.template data="{data}"/>
   </div>
-{/template}
+</template>
 
 
 describe("Sub- and parent- template scope interactions", function () {

--- a/test/rt/svg.spec.hsp
+++ b/test/rt/svg.spec.hsp
@@ -2,11 +2,11 @@ var hsp = require("hsp/rt");
 var browser = require("hsp/rt/browser");
 var ht = require("hsp/utils/hashtester");
 
-{template svgTest()}
+<template svgTest()>
     <svg>
         <circle cx="60" cy="60" r="50" stroke="black" stroke-width="5" fill="silver"/>
     </svg>
-{/template}
+</template>
 
 describe('svg support', function() {
 

--- a/test/rt/text.spec.hsp
+++ b/test/rt/text.spec.hsp
@@ -16,36 +16,36 @@
 var hsp=require("hsp/rt"),
     json=require("hsp/json");
 
-{template hello1()}
+<template hello1()>
     Hello World!
-{/template}
+</template>
 
-{template hello2(person)}
+<template hello2(person)>
     Hello {person.name}!
-{/template}
+</template>
 
-{template hello3(person)}
+<template hello3(person)>
     Hello {person.firstName} {person.lastName}!
-{/template}
+</template>
 
 // same as hello3 but with unbound variable on the lastName
-{template hello4(person)}
+<template hello4(person)>
     Hello {person.firstName} {:person.lastName}!
-{/template}
+</template>
 
 // same as hello3 but with a string parameter
-{template hello5(name)}
+<template hello5(name)>
     Hello {name}!
-{/template}
+</template>
 
 var globalValue="foo";
-{template hello6()}
+<template hello6()>
     {globalValue}
-{/template}
+</template>
 
-{template hello7(d)}
+<template hello7(d)>
     {concat(d.firstName,d.lastName)}
-{/template}
+</template>
 
 function concat(x,y) {
     return x+"-"+y;
@@ -56,16 +56,16 @@ function compare(x,y) {
     return r;
 }
 
-{template hello8(d)}
+<template hello8(d)>
     {if compare(d.firstName,d.lastName)}
         OK
     {/if}
-{/template}
+</template>
 
 var globalValueInt=0;
-{template hello9()}
+<template hello9()>
     {globalValueInt}
-{/template}
+</template>
 
 
 describe("Text Nodes", function () {

--- a/test/utils/eventgenerator.spec.hsp
+++ b/test/utils/eventgenerator.spec.hsp
@@ -1,13 +1,13 @@
 var fireEvent = require("hsp/utils/eventgenerator").fireEvent,
     fireKeydownEventAdaptedForKeyNav = require("hsp/utils/eventgenerator").fireKeydownEventAdaptedForKeyNav;
 
-{template testEventGenerator(ctl)}
+<template testEventGenerator(ctl)>
     <div onclick="{ctl.handleOtherClick()}"  onkeydown="{ctl.handleOtherKeyDown()}" style="display:none;">
         <div id="testZone" ionclick="{ctl.handleClick()}"  onkeydown="{ctl.handleKeyDown()}" >
         </div>
         <input id="testInput" type="text" onfocus="{ctl.handleFocus()}"/>
     </div>
-{/template}
+</template>
 
 describe("Event generator utils", function () {
     it("tests event generation", function () {

--- a/test/utils/hashtester.spec.hsp
+++ b/test/utils/hashtester.spec.hsp
@@ -2,7 +2,7 @@ var ht=require("hsp/utils/hashtester"),
     log=require("hsp/rt/log"),
     $set=require("hsp/$set");
 
-{template testContent(data)}
+<template testContent(data)>
     <div class="foo1 foo2">
         <span class="sometext" title="Hello World!">Here is some text</span>
         <span class="count" onclick="{increaseCount(data,1)}" ondblclick="{increaseCount(data,5)}">{data.count}</span>
@@ -12,7 +12,7 @@ var ht=require("hsp/utils/hashtester"),
         <li class="foo2 bar2">item 2</li>
         <li>item 3</li>
     </ul>
-{/template}
+</template>
 
 function increaseCount(d,incr) {
     $set(d,"count",d.count+incr);


### PR DESCRIPTION
Opening this PR as a preview, it's just the first step - do you think it should be merged now, or later when all the features are implemented?

---

First of the steps needed for the HTML syntax introduction
as proposed in https://github.com/ariatemplates/hashspace/wiki/HTML-Syntax-Proposal

This just:

1) changes `{template}` syntax to `<template>`
2) removes the support for the old `# template` syntax

(all changes to the parser, samples, docs and test are all in this
commit).

The rest of the changes (introducing `<script>` for JS part, making
`<template>` accept HTMLish attribs) are to come.
