### PR TITLE
fix #225 Improve compiler error for attributes with missing quotes

### DIFF
--- a/test/compiler/errsamples/attribute1.txt
+++ b/test/compiler/errsamples/attribute1.txt
@@ -1,16 +1,20 @@
 ##### Template:
 <template test()>
     <div data-foo="0"></div>
-    <div data-foo-bar="1"></div>
+    <#cpt data-foo_bar="1"></#cpt>
     <div data:foo="2"></div>
+    <input type="text" autocomplete/>
+    <input autocomplete type="text"/>
     <div data:="3"></div>
+    <#cpt data:foo:bar="3" $foo="bar"></#cpt>
+    <input $foo%^ type="text" ?bar;/>
 </template>
 
 ##### Errors:
 [
-  {
-    "description": "Invalid HTML element syntax",
-    "line": 5,
-    "column": 5
-  }
+  {"description": "Invalid attribute name: \"data:\"", "line": 7, "column": 10},
+  {"description": "Invalid attribute name: \"data:foo:bar\"", "line": 8, "column": 11},
+  {"description": "Invalid attribute name: \"$foo\"", "line": 8, "column": 28},
+  {"description": "Invalid attribute name: \"$foo%^\"", "line": 9, "column": 12},
+  {"description": "Invalid attribute name: \"?bar;\"", "line": 9, "column": 31}
 ]

--- a/test/compiler/errsamples/attribute2.txt
+++ b/test/compiler/errsamples/attribute2.txt
@@ -1,16 +1,17 @@
 ##### Template:
 <template test()>
-    <div data-foo="0"></div>
-    <div data-foo-bar="1"></div>
-    <div data:foo="2"></div>
-    <div data:foo:bar="3"></div>
+    <div foo=""></div>
+    <div foo="0"></div>
+    <div foo="abc"></div>
+    <div foo="{a.b}"></div>
+    <div foo="bar{a.b}"></div>
+    <div foo="bar{a.b"></div>
+    <#cpt fo$o="bar{a.b"></#cpt>
 </template>
 
 ##### Errors:
 [
-  {
-    "description": "Invalid HTML element syntax",
-    "line": 5,
-    "column": 5
-  }
+  {"description": "Invalid attribute value: \"bar{a.b\"", "line": 7, "column": 15},
+  {"description": "Invalid attribute name: \"fo$o\"", "line": 8, "column": 11},
+  {"description": "Invalid attribute value: \"bar{a.b\"", "line": 8, "column": 17}
 ]

--- a/test/compiler/errsamples/attribute3.txt
+++ b/test/compiler/errsamples/attribute3.txt
@@ -1,0 +1,15 @@
+##### Template:
+<template test()>
+    <div foo=5></div>
+    <div foo=5"></div>
+    <div foo="5></div>
+    <div foo={bar}></div>
+</template>
+
+##### Errors:
+[
+  {"description": "Missing quote(s) around attribute value: 5", "line": 2, "column": 14},
+  {"description": "Missing quote(s) around attribute value: 5\"", "line": 3, "column": 14},
+  {"description": "Missing quote(s) around attribute value: \"5", "line": 4, "column": 14},
+  {"description": "Missing quote(s) around attribute value: {bar}", "line": 5, "column": 14}
+]

--- a/test/compiler/errsamples/attribute4.txt
+++ b/test/compiler/errsamples/attribute4.txt
@@ -1,0 +1,13 @@
+##### Template:
+<template test()>
+    <div f$oo="foo{a.b.}A{"></div>
+    <div foo="bar"baz></div>
+</template>
+
+##### Errors:
+[
+  {"description": "Invalid attribute name: \"f$oo\"", "line": 2, "column": 10},
+  {"description": "Invalid expression: 'a.b.'", "line": 2, "column": 19},
+  {"description": "Invalid attribute value: \"foo{a.b.}A{\"", "line": 2, "column": 16},
+  {"description": "Attribute value \"bar\" has trailing chars: baz", "line": 3, "column": 15}
+]

--- a/test/compiler/errsamples/element4.txt
+++ b/test/compiler/errsamples/element4.txt
@@ -8,14 +8,8 @@
 ##### Errors:
 [
   {
-    "description": "Invalid HTML element syntax",
+    "description": "Attribute value \"Some text class=\" has trailing chars: foo\"",
     "line": 2,
-    "column": 5,
-    "code": "<div title=\"Some text class=\"foo\">"
-  },
-  {
-    "description": "End element </div> does not match any <div> element",
-    "line": 4,
-    "column": 5
+    "column": 17,
   }
 ]


### PR DESCRIPTION
This PR adds error messages for wrong attributes of HTML elements and components.
Please have a look at the tests first.

It doesn't takes care of allowing single quotes, @olaf-k is working on this part.
