### PR TITLE
Browserify again

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -272,44 +272,36 @@ module.exports = function (grunt) {
     },
     browserify: {
       runtime: {
-        files: [{dest: 'dist/hashspace-browserify.js', src: ['hsp/rt.js']}],
+        files: [{
+          dest: 'dist/hashspace-browserify.js',
+          src: ['hsp/rt.js']
+        }],
         options: {
-          aliasMappings: [
-            {
-              cwd: "hsp",
-              src: ['*.js'],
-              dest: 'hsp'
-            },
-            {
-              cwd: "hsp/rt",
-              src: ['*.js'],
-              dest: 'hsp/rt'
-            }
-          ]
+          browserifyOptions: {
+            standalone: "hsp"
+          }
         }
       },
       compiler: {
-        files: [{dest: 'dist/hashspace-browserify-compiler.js', src: ['hsp/compiler/compiler.js']}],
+        files: [{
+          dest: 'dist/hashspace-browserify-compiler.js',
+          src: ['hsp/compiler/browser.js']
+        }],
         options: {
-          aliasMappings: [
-            {
-              cwd: "hsp/compiler",
-              src: ['compiler.js'],
-              dest: 'hsp'
-            }
-          ]
+          browserifyOptions: {
+            standalone: "hspcompile"
+          }
         }
       },
       gestures: {
-        files: [{dest: 'dist/hashspace-browserify-gestures.js', src: ['hsp/gestures/index.js']}],
+        files: [{
+          dest: 'dist/hashspace-browserify-gestures.js',
+          src: ['hsp/gestures/index.js']
+        }],
         options: {
-          aliasMappings: [
-            {
-              cwd: "hsp/gestures",
-              src: ['*.js'],
-              dest: 'hsp/gestures'
-            }
-          ]
+          browserifyOptions: {
+            standalone: "hsp.gestures"
+          }
         }
       }
     },

--- a/hsp/compiler/browser.js
+++ b/hsp/compiler/browser.js
@@ -1,0 +1,42 @@
+var compiler = require("./compiler");
+
+/*!
+ * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+ */
+var reCommentContents = /\/\*!?(?:\@preserve)?[ \t]*(?:\r\n|\n)([\s\S]*?)(?:\r\n|\n)\s*\*\//;
+
+module.exports = function (fn) {
+	if (typeof fn !== 'function') {
+		throw new TypeError('Expected a function');
+	}
+
+	var match = reCommentContents.exec(fn.toString());
+
+	if (!match) {
+		throw new TypeError('Multiline comment missing.');
+	}
+
+	var result = compiler.compile(match[1], "dynamic_code.js", {
+		globalRef: "hsp",
+		mode: "global",
+		includeSyntaxTree: true
+	});
+
+	// Extract the templates from the eval code
+	var extract = [];
+	for (var name in result.codeFragments) {
+		if (result.codeFragments.hasOwnProperty(name)) {
+			extract.push(name + ":" + name);
+		}
+	}
+
+	function wrap (code, templatesJson) {
+		var result = "(function () {\n" + code;
+		result += "\nreturn {";
+		result += templatesJson.join(",");
+		result += "}})()";
+		return result;
+	}
+
+	return eval(wrap(result.code, extract));
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-verifylowercase": "~0.2.0",
     "grunt-leading-indent": "~0.1.0",
     "grunt-mocha-test": "~0.7.0",
-    "grunt-browserify": "~2.0.0",
+    "grunt-browserify": "^3.0.1",
     "grunt-peg": "~1.5.0",
     "grunt-karma": "~0.8.0",
     "grunt-jscs-checker": "~0.4.0",


### PR DESCRIPTION
I recently tried again to use hashspace with browserify and I noticed that the browserify build is broken, because of the update of grunt-browserify.
There are also some changes in hashspace that makes the old configuration wrong.

So here is another attempt to use hashspace with browserify. This is how you use it inside the browser

``` html
<!DOCTYPE html>
<html>
    <head>
        <title>HashSpace</title>
    </head>
    <body>
        <div id="banana"></div>

        <script src="dist/hashspace-browserify.js"></script>
        <script src="dist/hashspace-browserify-compiler.js"></script>
        <script>
            var template = hspcompile(function () {/*
                <template banana(name)>
                    Hello {name}!
                </template>
            */});

            template.banana("Fabio").render("banana");
        </script>
    </body>
</html>
```

Now I don't really expect this PR to be merged, it's more a conversation starter. I see that there's a strong traction for using `noder` and the two approaches can be hardly maintained together.

@benouat You'll be glad to know that with this PR browserify generates UMD code, so maybe #3 gets fixed.
