### PR TITLE
Wrong scope when calling simple functions (binary function operator)

### DIFF
--- a/hsp/expressions/evaluator.js
+++ b/hsp/expressions/evaluator.js
@@ -50,7 +50,7 @@ var BINARY_OPERATORS = {
     '||': function (scope, left, right) { return left || right; },
     '&&': function (scope, left, right) { return left && right; },
     '(': function (scope, left, right) { //function call on a scope
-        return left.apply(left, right);
+        return left.apply(null, right);
     },
     'new': function (scope, constrFunc, args) { //constructor invocation
         var inst = Object.create(constrFunc.prototype);

--- a/test/expressions/manipulator.spec.js
+++ b/test/expressions/manipulator.spec.js
@@ -94,6 +94,15 @@ describe('getValue', function () {
         expect(expression('obj[foo.bar("s" + "th")]').getValue({obj: {STH: 'else'}, foo: {bar: function(sth) {return sth.toUpperCase(); }}})).to.equal('else');
     });
 
+    it('should evaluate functions with correct scope', function () {
+        var foo = function () {
+            return this;
+        };
+        expect(expression('foo()').getValue({
+            foo : foo
+        })).to.be(foo());
+    });
+
     it('should allow chained function calls', function() {
         expect(expression('foo().bar()').getValue({
             foo: function () {


### PR DESCRIPTION
This PR fixes the scope when calling functions from expressions, to match the normal javascript behavior.
