### PR TITLE
fix double quotes in compiler error messages introduced by #307

### DIFF
--- a/hsp/compiler/treebuilder/syntaxTree.js
+++ b/hsp/compiler/treebuilder/syntaxTree.js
@@ -630,7 +630,7 @@ var SyntaxTree = klass({
                     var error = attribute.errors[j];
                     var msg = "Invalid attribute";
                     if (error.errorType === "name") {
-                        msg = "Invalid attribute name: \"" + error.value + "\"";
+                        msg = "Invalid attribute name: \\\"" + error.value + "\\\"";
                     }
                     else if (error.errorType === "value" || error.errorType === "tail") {
                         var valueAsString = "";
@@ -650,14 +650,14 @@ var SyntaxTree = klass({
                             }
                         }
                         if (typeof error.tail === "undefined") {
-                            msg = "Invalid attribute value: \"" + valueAsString + "\"";
+                            msg = "Invalid attribute value: \\\"" + valueAsString + "\\\"";
                         }
                         else {
-                            msg = "Attribute value \"" + valueAsString + "\" has trailing chars: " + error.tail;
+                            msg = "Attribute value \\\"" + valueAsString + "\\\" has trailing chars: " + error.tail;
                         }
                     }
                     else if (error.errorType === "invalidquotes") {
-                        msg = "Missing quote(s) around attribute value: " + error.value;
+                        msg = "Missing quote(s) around attribute value: " + error.value.replace("\"", "\\\"");
                     }
                     this._logError(msg, error);
                 }

--- a/test/compiler/errsamples/attribute1.txt
+++ b/test/compiler/errsamples/attribute1.txt
@@ -12,9 +12,9 @@
 
 ##### Errors:
 [
-  {"description": "Invalid attribute name: \"data:\"", "line": 7, "column": 10},
-  {"description": "Invalid attribute name: \"data:foo:bar\"", "line": 8, "column": 11},
-  {"description": "Invalid attribute name: \"$foo\"", "line": 8, "column": 28},
-  {"description": "Invalid attribute name: \"$foo%^\"", "line": 9, "column": 12},
-  {"description": "Invalid attribute name: \"?bar;\"", "line": 9, "column": 31}
+  {"description": "Invalid attribute name: \\\"data:\\\"", "line": 7, "column": 10},
+  {"description": "Invalid attribute name: \\\"data:foo:bar\\\"", "line": 8, "column": 11},
+  {"description": "Invalid attribute name: \\\"$foo\\\"", "line": 8, "column": 28},
+  {"description": "Invalid attribute name: \\\"$foo%^\\\"", "line": 9, "column": 12},
+  {"description": "Invalid attribute name: \\\"?bar;\\\"", "line": 9, "column": 31}
 ]

--- a/test/compiler/errsamples/attribute2.txt
+++ b/test/compiler/errsamples/attribute2.txt
@@ -11,7 +11,7 @@
 
 ##### Errors:
 [
-  {"description": "Invalid attribute value: \"bar{a.b\"", "line": 7, "column": 15},
-  {"description": "Invalid attribute name: \"fo$o\"", "line": 8, "column": 11},
-  {"description": "Invalid attribute value: \"bar{a.b\"", "line": 8, "column": 17}
+  {"description": "Invalid attribute value: \\\"bar{a.b\\\"", "line": 7, "column": 15},
+  {"description": "Invalid attribute name: \\\"fo$o\\\"", "line": 8, "column": 11},
+  {"description": "Invalid attribute value: \\\"bar{a.b\\\"", "line": 8, "column": 17}
 ]

--- a/test/compiler/errsamples/attribute3.txt
+++ b/test/compiler/errsamples/attribute3.txt
@@ -9,7 +9,7 @@
 ##### Errors:
 [
   {"description": "Missing quote(s) around attribute value: 5", "line": 2, "column": 14},
-  {"description": "Missing quote(s) around attribute value: 5\"", "line": 3, "column": 14},
-  {"description": "Missing quote(s) around attribute value: \"5", "line": 4, "column": 14},
+  {"description": "Missing quote(s) around attribute value: 5\\\"", "line": 3, "column": 14},
+  {"description": "Missing quote(s) around attribute value: \\\"5", "line": 4, "column": 14},
   {"description": "Missing quote(s) around attribute value: {bar}", "line": 5, "column": 14}
 ]

--- a/test/compiler/errsamples/attribute4.txt
+++ b/test/compiler/errsamples/attribute4.txt
@@ -6,8 +6,8 @@
 
 ##### Errors:
 [
-  {"description": "Invalid attribute name: \"f$oo\"", "line": 2, "column": 10},
+  {"description": "Invalid attribute name: \\\"f$oo\\\"", "line": 2, "column": 10},
   {"description": "Invalid expression: 'a.b.'", "line": 2, "column": 19},
-  {"description": "Invalid attribute value: \"foo{a.b.}A{\"", "line": 2, "column": 16},
-  {"description": "Attribute value \"bar\" has trailing chars: baz", "line": 3, "column": 15}
+  {"description": "Invalid attribute value: \\\"foo{a.b.}A{\\\"", "line": 2, "column": 16},
+  {"description": "Attribute value \\\"bar\\\" has trailing chars: baz", "line": 3, "column": 15}
 ]

--- a/test/compiler/errsamples/element4.txt
+++ b/test/compiler/errsamples/element4.txt
@@ -8,7 +8,7 @@
 ##### Errors:
 [
   {
-    "description": "Attribute value \"Some text class=\" has trailing chars: foo\"",
+    "description": "Attribute value \\\"Some text class=\\\" has trailing chars: foo\"",
     "line": 2,
     "column": 17,
   }


### PR DESCRIPTION
Some error messages were not correctly displayed in the playground ...
